### PR TITLE
Use occam.example.com as registry prefix

### DIFF
--- a/cache_volume_names.go
+++ b/cache_volume_names.go
@@ -6,7 +6,7 @@ import (
 )
 
 func CacheVolumeNames(name string) []string {
-	refName := []byte(fmt.Sprintf("index.docker.io/library/%s:latest", name))
+	refName := []byte(fmt.Sprintf("%s:latest", name))
 
 	sum := sha256.Sum256(refName)
 

--- a/cache_volume_names_test.go
+++ b/cache_volume_names_test.go
@@ -14,9 +14,9 @@ func testCacheVolumeNames(t *testing.T, context spec.G, it spec.S) {
 
 	it("returns the name of the cache volumes that are assigned to an image", func() {
 		Expect(occam.CacheVolumeNames("some-app")).To(Equal([]string{
-			"pack-cache-891d1f8dedc9.build",
-			"pack-cache-891d1f8dedc9.launch",
-			"pack-cache-891d1f8dedc9.cache",
+			"pack-cache-16fe664c76f0.build",
+			"pack-cache-16fe664c76f0.launch",
+			"pack-cache-16fe664c76f0.cache",
 		}))
 	})
 }

--- a/random_name.go
+++ b/random_name.go
@@ -19,5 +19,5 @@ func RandomName() (string, error) {
 		return "", err
 	}
 
-	return strings.ToLower(fmt.Sprintf("occam-%s", guid)), nil
+	return strings.ToLower(fmt.Sprintf("occam.example.com/%s", guid)), nil
 }

--- a/random_name_test.go
+++ b/random_name_test.go
@@ -15,6 +15,6 @@ func testRandomName(t *testing.T, context spec.G, it spec.S) {
 	it("generates a random name", func() {
 		name, err := occam.RandomName()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(name).To(MatchRegexp(`^occam\-[0123456789abcdefghjkmnpqrstvwxyz]{26}$`))
+		Expect(name).To(MatchRegexp(`^occam\.example\.com/[0123456789abcdefghjkmnpqrstvwxyz]{26}$`))
 	})
 }


### PR DESCRIPTION
Using a custom registry domain ensures that we won't inadvertently trigger the run-image mirroring code that would be triggered when naming an image without a domain.