### PR TITLE
Serve matcher

### DIFF
--- a/matchers/init_test.go
+++ b/matchers/init_test.go
@@ -11,5 +11,6 @@ func TestUnitMatchers(t *testing.T) {
 	suite := spec.New("occam/matchers", spec.Report(report.Terminal{}))
 	suite("BeAvailable", testBeAvailable)
 	suite("ContainLines", testContainLines)
+	suite("Serve", testServe)
 	suite.Run(t)
 }

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -61,7 +61,7 @@ func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error)
 func (matcher *ServeMatcher) FailureMessage(actual interface{}) (message string) {
 	container := actual.(occam.Container)
 
-	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nto equal:\n\n\t%s",
+	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nto contain:\n\n\t%s",
 		container.ID,
 		matcher.ActualResponse,
 		matcher.ExpectedResponse,
@@ -77,7 +77,7 @@ func (matcher *ServeMatcher) FailureMessage(actual interface{}) (message string)
 func (matcher *ServeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	container := actual.(occam.Container)
 
-	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nnot to equal:\n\n\t%s",
+	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nnot to contain:\n\n\t%s",
 		container.ID,
 		matcher.ActualResponse,
 		matcher.ExpectedResponse,

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -10,10 +10,11 @@ import (
 	"github.com/paketo-buildpacks/occam"
 )
 
-func Serve(expectedResponse string, port string) types.GomegaMatcher {
+func Serve(expectedResponse string, port string, endpoint string) types.GomegaMatcher {
 	return &ServeMatcher{
 		ExpectedResponse: expectedResponse,
 		port:             port,
+		endpoint:         endpoint,
 		Docker:           occam.NewDocker(),
 		ActualResponse:   "",
 	}
@@ -22,6 +23,7 @@ func Serve(expectedResponse string, port string) types.GomegaMatcher {
 type ServeMatcher struct {
 	ExpectedResponse string
 	port             string
+	endpoint         string
 	Docker           occam.Docker
 	ActualResponse   string
 }
@@ -36,7 +38,7 @@ func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error)
 		return false, fmt.Errorf("ServeMatcher looking for response from container port %s which is not in container port map", matcher.port)
 	}
 
-	response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort(matcher.port)))
+	response, err := http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort(matcher.port), matcher.endpoint))
 
 	if err != nil {
 		return false, err

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -4,19 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 
-	"github.com/onsi/gomega/types"
 	"github.com/paketo-buildpacks/occam"
 )
 
-type ServeMatcherInterface interface {
-	types.GomegaMatcher
-	OnPort(string) *ServeMatcher
-	WithEndpoint(string) *ServeMatcher
-}
-
-func Serve(expectedResponse string) ServeMatcherInterface {
+func Serve(expectedResponse string) *ServeMatcher {
 	return &ServeMatcher{
 		ExpectedResponse: expectedResponse,
 		Docker:           occam.NewDocker(),
@@ -26,13 +20,13 @@ func Serve(expectedResponse string) ServeMatcherInterface {
 
 type ServeMatcher struct {
 	ExpectedResponse string
-	port             string
+	port             int
 	endpoint         string
 	Docker           occam.Docker
 	ActualResponse   string
 }
 
-func (sm *ServeMatcher) OnPort(port string) *ServeMatcher {
+func (sm *ServeMatcher) OnPort(port int) *ServeMatcher {
 	sm.port = port
 	return sm
 }
@@ -42,17 +36,18 @@ func (sm *ServeMatcher) WithEndpoint(endpoint string) *ServeMatcher {
 	return sm
 }
 
-func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error) {
+func (sm *ServeMatcher) Match(actual interface{}) (success bool, err error) {
 	container, ok := actual.(occam.Container)
 	if !ok {
 		return false, fmt.Errorf("ServeMatcher expects an occam.Container, received %T", actual)
 	}
 
 	// no port specified, and there's only one to choose from
-	if matcher.port == "" {
+	port := strconv.Itoa(sm.port)
+	if port == "0" {
 		if len(container.Ports) == 1 {
 			for p := range container.Ports {
-				matcher.port = p
+				port = p
 				break
 			}
 		} else {
@@ -60,12 +55,12 @@ func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error)
 		}
 	}
 
-	if _, ok := container.Ports[matcher.port]; !ok {
+	if _, ok := container.Ports[port]; !ok {
 		// EITHER: you have multiple ports, didn't specify OR you specified a bad port
-		return false, fmt.Errorf("ServeMatcher looking for response from container port %s which is not in container port map", matcher.port)
+		return false, fmt.Errorf("ServeMatcher looking for response from container port %s which is not in container port map", port)
 	}
 
-	response, err := http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort(matcher.port), matcher.endpoint))
+	response, err := http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort(port), sm.endpoint))
 
 	if err != nil {
 		return false, err
@@ -78,41 +73,41 @@ func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error)
 			return false, err
 		}
 
-		matcher.ActualResponse = string(content)
+		sm.ActualResponse = string(content)
 
-		if response.StatusCode == http.StatusOK && strings.Contains(string(content), matcher.ExpectedResponse) {
+		if response.StatusCode == http.StatusOK && strings.Contains(string(content), sm.ExpectedResponse) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func (matcher *ServeMatcher) FailureMessage(actual interface{}) (message string) {
+func (sm *ServeMatcher) FailureMessage(actual interface{}) (message string) {
 	container := actual.(occam.Container)
 
 	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nto contain:\n\n\t%s",
 		container.ID,
-		matcher.ActualResponse,
-		matcher.ExpectedResponse,
+		sm.ActualResponse,
+		sm.ExpectedResponse,
 	)
 
-	if logs, _ := matcher.Docker.Container.Logs.Execute(container.ID); logs != nil {
+	if logs, _ := sm.Docker.Container.Logs.Execute(container.ID); logs != nil {
 		message = fmt.Sprintf("%s\n\nContainer logs:\n\n%s", message, logs)
 	}
 
 	return message
 }
 
-func (matcher *ServeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (sm *ServeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	container := actual.(occam.Container)
 
 	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nnot to contain:\n\n\t%s",
 		container.ID,
-		matcher.ActualResponse,
-		matcher.ExpectedResponse,
+		sm.ActualResponse,
+		sm.ExpectedResponse,
 	)
 
-	if logs, _ := matcher.Docker.Container.Logs.Execute(container.ID); logs != nil {
+	if logs, _ := sm.Docker.Container.Logs.Execute(container.ID); logs != nil {
 		message = fmt.Sprintf("%s\n\nContainer logs:\n\n%s", message, logs)
 	}
 

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -1,0 +1,91 @@
+package matchers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/onsi/gomega/types"
+	"github.com/paketo-buildpacks/occam"
+)
+
+func Serve(expectedResponse string, port string) types.GomegaMatcher {
+	return &ServeMatcher{
+		ExpectedResponse: expectedResponse,
+		port:             port,
+		Docker:           occam.NewDocker(),
+		ActualResponse:   "",
+	}
+}
+
+type ServeMatcher struct {
+	ExpectedResponse string
+	port             string
+	Docker           occam.Docker
+	ActualResponse   string
+}
+
+func (matcher *ServeMatcher) Match(actual interface{}) (success bool, err error) {
+	container, ok := actual.(occam.Container)
+	if !ok {
+		return false, fmt.Errorf("ServeMatcher expects an occam.Container, received %T", actual)
+	}
+
+	if _, ok := container.Ports[matcher.port]; !ok {
+		return false, fmt.Errorf("ServeMatcher looking for response from container port %s which is not in container port map", matcher.port)
+	}
+
+	response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort(matcher.port)))
+
+	if err != nil {
+		return false, err
+	}
+
+	if response != nil {
+		defer response.Body.Close()
+		content, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return false, err
+		}
+
+		matcher.ActualResponse = string(content)
+
+		if response.StatusCode == http.StatusOK && strings.Contains(string(content), matcher.ExpectedResponse) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (matcher *ServeMatcher) FailureMessage(actual interface{}) (message string) {
+	container := actual.(occam.Container)
+
+	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nto equal:\n\n\t%s",
+		container.ID,
+		matcher.ActualResponse,
+		matcher.ExpectedResponse,
+	)
+
+	if logs, _ := matcher.Docker.Container.Logs.Execute(container.ID); logs != nil {
+		message = fmt.Sprintf("%s\n\nContainer logs:\n\n%s", message, logs)
+	}
+
+	return message
+}
+
+func (matcher *ServeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	container := actual.(occam.Container)
+
+	message = fmt.Sprintf("Expected the response from docker container %s:\n\n\t%s\n\nnot to equal:\n\n\t%s",
+		container.ID,
+		matcher.ActualResponse,
+		matcher.ExpectedResponse,
+	)
+
+	if logs, _ := matcher.Docker.Container.Logs.Execute(container.ID); logs != nil {
+		message = fmt.Sprintf("%s\n\nContainer logs:\n\n%s", message, logs)
+	}
+
+	return message
+}

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -23,7 +23,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		matcher matchers.ServeMatcherInterface
+		matcher *matchers.ServeMatcher
 	)
 
 	it.Before(func() {
@@ -35,8 +35,9 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			actual interface{}
 			server *httptest.Server
 		)
+
 		it.Before(func() {
-			matcher.OnPort("8080").WithEndpoint("/endpoint")
+			matcher.OnPort(8080).WithEndpoint("/endpoint")
 		})
 
 		context("the http request succeeds and response contains substring", func() {
@@ -76,6 +77,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns true", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).NotTo(HaveOccurred())
@@ -119,6 +121,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns false", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).NotTo(HaveOccurred())
@@ -163,6 +166,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns false", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).NotTo(HaveOccurred())
@@ -207,6 +211,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns false", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).NotTo(HaveOccurred())
@@ -246,6 +251,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 				it.After(func() {
 					server.Close()
 				})
+
 				it("returns an error", func() {
 					result, err := matcher.Match(actual)
 					Expect(err).To(MatchError(ContainSubstring("ServeMatcher looking for response from container port 8080 which is not in container port map")))
@@ -287,6 +293,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 				it.After(func() {
 					server.Close()
 				})
+
 				it("returns an error", func() {
 					result, err := matcher.Match(actual)
 					Expect(err).To(HaveOccurred())
@@ -301,6 +308,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			actual interface{}
 			server *httptest.Server
 		)
+
 		context("there's only one container port mapping", func() {
 			it.Before(func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -335,6 +343,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns true", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).NotTo(HaveOccurred())
@@ -379,6 +388,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			it.After(func() {
 				server.Close()
 			})
+
 			it("returns true", func() {
 				result, err := matcher.Match(actual)
 				Expect(err).To(MatchError(ContainSubstring("container has multiple port mappings, but none were specified. Please specify via the OnPort method")))

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -324,7 +324,7 @@ Expected the response from docker container some-container-id:
 
 	actual response
 
-to equal:
+to contain:
 
 	expected response
 
@@ -363,7 +363,7 @@ Expected the response from docker container some-container-id:
 
 	actual response
 
-not to equal:
+not to contain:
 
 	expected response
 

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -28,7 +28,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		matcher = matchers.Serve("some string", "8080")
+		matcher = matchers.Serve("some string", "8080", "/endpoint")
 	})
 
 	context("Match", func() {
@@ -46,7 +46,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 					}
 
 					switch req.URL.Path {
-					case "/":
+					case "/endpoint":
 						w.WriteHeader(http.StatusOK)
 						fmt.Fprintln(w, "some string")
 					default:
@@ -90,7 +90,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 					}
 
 					switch req.URL.Path {
-					case "/":
+					case "/endpoint":
 						// do nothing
 					default:
 						fmt.Fprintln(w, "unknown path")
@@ -133,7 +133,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 					}
 
 					switch req.URL.Path {
-					case "/":
+					case "/endpoint":
 						w.WriteHeader(http.StatusNotFound)
 						fmt.Fprintln(w, "some string")
 					default:
@@ -177,7 +177,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 					}
 
 					switch req.URL.Path {
-					case "/":
+					case "/endpoint":
 						w.WriteHeader(http.StatusOK)
 						fmt.Fprintln(w, "another string")
 					default:
@@ -222,7 +222,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 						}
 
 						switch req.URL.Path {
-						case "/":
+						case "/endpoint":
 							w.WriteHeader(http.StatusOK)
 							fmt.Fprintln(w, "some string")
 						default:
@@ -262,7 +262,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 						}
 
 						switch req.URL.Path {
-						case "/":
+						case "/endpoint":
 							w.WriteHeader(http.StatusOK)
 							fmt.Fprintln(w, "some string")
 						default:

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -1,0 +1,376 @@
+package matchers_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega/types"
+	"github.com/paketo-buildpacks/occam"
+	"github.com/paketo-buildpacks/occam/matchers"
+	"github.com/paketo-buildpacks/occam/matchers/fakes"
+	"github.com/paketo-buildpacks/packit/pexec"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+//go:generate faux --package github.com/paketo-buildpacks/occam --interface Executable --output fakes/executable.go
+
+func testServe(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		matcher types.GomegaMatcher
+	)
+
+	it.Before(func() {
+		matcher = matchers.Serve("some string", "8080")
+	})
+
+	context("Match", func() {
+		var (
+			actual interface{}
+			server *httptest.Server
+		)
+
+		context("when the http request succeeds and response contains substring", func() {
+			it.Before(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					if req.Method == http.MethodHead {
+						http.Error(w, "NotFound", http.StatusNotFound)
+						return
+					}
+
+					switch req.URL.Path {
+					case "/":
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintln(w, "some string")
+					default:
+						fmt.Fprintln(w, "unknown path")
+						t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+					}
+				}))
+
+				serverURL, err := url.Parse(server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual = occam.Container{
+					Ports: map[string]string{
+						"8080": serverURL.Port(),
+						"3000": "1234",
+						"4000": "4321",
+						"5000": "5678",
+					},
+					Env: map[string]string{
+						"PORT": "8080",
+					},
+				}
+			})
+
+			it.After(func() {
+				server.Close()
+			})
+			it("returns true", func() {
+				result, err := matcher.Match(actual)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		context("the http response is nil", func() {
+			it.Before(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					if req.Method == http.MethodHead {
+						http.Error(w, "NotFound", http.StatusNotFound)
+						return
+					}
+
+					switch req.URL.Path {
+					case "/":
+						// do nothing
+					default:
+						fmt.Fprintln(w, "unknown path")
+						t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+					}
+				}))
+
+				serverURL, err := url.Parse(server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual = occam.Container{
+					Ports: map[string]string{
+						"8080": serverURL.Port(),
+						"3000": "1234",
+						"4000": "4321",
+						"5000": "5678",
+					},
+					Env: map[string]string{
+						"PORT": "8080",
+					},
+				}
+			})
+
+			it.After(func() {
+				server.Close()
+			})
+			it("returns false", func() {
+				result, err := matcher.Match(actual)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		context("the response status code is not OK", func() {
+			it.Before(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					if req.Method == http.MethodHead {
+						http.Error(w, "NotFound", http.StatusNotFound)
+						return
+					}
+
+					switch req.URL.Path {
+					case "/":
+						w.WriteHeader(http.StatusNotFound)
+						fmt.Fprintln(w, "some string")
+					default:
+						fmt.Fprintln(w, "unknown path")
+						t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+					}
+				}))
+
+				serverURL, err := url.Parse(server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual = occam.Container{
+					Ports: map[string]string{
+						"8080": serverURL.Port(),
+						"3000": "1234",
+						"4000": "4321",
+						"5000": "5678",
+					},
+					Env: map[string]string{
+						"PORT": "8080",
+					},
+				}
+			})
+
+			it.After(func() {
+				server.Close()
+			})
+			it("returns false", func() {
+				result, err := matcher.Match(actual)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		context("the actual response does not match expected response", func() {
+			it.Before(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					if req.Method == http.MethodHead {
+						http.Error(w, "NotFound", http.StatusNotFound)
+						return
+					}
+
+					switch req.URL.Path {
+					case "/":
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintln(w, "another string")
+					default:
+						fmt.Fprintln(w, "unknown path")
+						t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+					}
+				}))
+
+				serverURL, err := url.Parse(server.URL)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual = occam.Container{
+					Ports: map[string]string{
+						"8080": serverURL.Port(),
+						"3000": "1234",
+						"4000": "4321",
+						"5000": "5678",
+					},
+					Env: map[string]string{
+						"PORT": "8080",
+					},
+				}
+			})
+
+			it.After(func() {
+				server.Close()
+			})
+			it("returns false", func() {
+				result, err := matcher.Match(actual)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		context("failure cases", func() {
+			context("the port is not in the container port mapping", func() {
+				it.Before(func() {
+					server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+						if req.Method == http.MethodHead {
+							http.Error(w, "NotFound", http.StatusNotFound)
+							return
+						}
+
+						switch req.URL.Path {
+						case "/":
+							w.WriteHeader(http.StatusOK)
+							fmt.Fprintln(w, "some string")
+						default:
+							fmt.Fprintln(w, "unknown path")
+							t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+						}
+					}))
+
+					actual = occam.Container{
+						Ports: map[string]string{
+							"3000": "1234",
+							"4000": "4321",
+							"5000": "5678",
+						},
+						Env: map[string]string{
+							"PORT": "8080",
+						},
+					}
+				})
+
+				it.After(func() {
+					server.Close()
+				})
+				it("returns an error", func() {
+					result, err := matcher.Match(actual)
+					Expect(err).To(MatchError(ContainSubstring("ServeMatcher looking for response from container port 8080 which is not in container port map")))
+					Expect(result).To(BeFalse())
+				})
+			})
+
+			context("the request URL is malformed", func() {
+				it.Before(func() {
+					server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+						if req.Method == http.MethodHead {
+							http.Error(w, "NotFound", http.StatusNotFound)
+							return
+						}
+
+						switch req.URL.Path {
+						case "/":
+							w.WriteHeader(http.StatusOK)
+							fmt.Fprintln(w, "some string")
+						default:
+							fmt.Fprintln(w, "unknown path")
+							t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+						}
+					}))
+
+					actual = occam.Container{
+						Ports: map[string]string{
+							"8080": "malformed port",
+							"3000": "1234",
+							"4000": "4321",
+							"5000": "5678",
+						},
+						Env: map[string]string{
+							"PORT": "8080",
+						},
+					}
+				})
+
+				it.After(func() {
+					server.Close()
+				})
+				it("returns an error", func() {
+					result, err := matcher.Match(actual)
+					Expect(err).To(HaveOccurred())
+					Expect(result).To(BeFalse())
+				})
+			})
+		})
+	})
+
+	context("FailureMessage", func() {
+		var actual interface{}
+
+		it.Before(func() {
+			executable := &fakes.Executable{}
+			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+				fmt.Fprintln(execution.Stdout, "some logs")
+				return nil
+			}
+
+			matcher = &matchers.ServeMatcher{
+				Docker:           occam.NewDocker().WithExecutable(executable),
+				ActualResponse:   "actual response",
+				ExpectedResponse: "expected response",
+			}
+
+			actual = occam.Container{
+				ID: "some-container-id",
+			}
+		})
+
+		it("returns a useful error message", func() {
+			message := matcher.FailureMessage(actual)
+			Expect(message).To(ContainSubstring(strings.TrimSpace(`
+Expected the response from docker container some-container-id:
+
+	actual response
+
+to equal:
+
+	expected response
+
+Container logs:
+
+some logs
+	`)))
+		})
+	})
+
+	context("NegatedFailureMessage", func() {
+		var actual interface{}
+
+		it.Before(func() {
+			executable := &fakes.Executable{}
+			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+				fmt.Fprintln(execution.Stdout, "some logs")
+				return nil
+			}
+
+			matcher = &matchers.ServeMatcher{
+				Docker:           occam.NewDocker().WithExecutable(executable),
+				ActualResponse:   "actual response",
+				ExpectedResponse: "expected response",
+			}
+
+			actual = occam.Container{
+				ID: "some-container-id",
+			}
+		})
+
+		it("returns a useful error message", func() {
+			message := matcher.NegatedFailureMessage(actual)
+			Expect(message).To(ContainSubstring(strings.TrimSpace(`
+Expected the response from docker container some-container-id:
+
+	actual response
+
+not to equal:
+
+	expected response
+
+Container logs:
+
+some logs
+	`)))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Implements a matcher that  checks whether a certain port on a container responds to an HTTP GET with a certain response. It can be used like:
`Eventually(container).Should(Serve("expected HTML content", "portOnContainer"))`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
@sophiewigmore and I noticed that we'd be repeating code to check the response from a certain app endpoint _very often_ in our tests for the samples repo. We figured it would be nice to have a matcher that cleanly checks this.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
