### PR TITLE
Update CacheVolumeNames generation to support pack 0.17

### DIFF
--- a/cache_volume_names.go
+++ b/cache_volume_names.go
@@ -3,16 +3,22 @@ package occam
 import (
 	"crypto/sha256"
 	"fmt"
+	"strings"
 )
 
 func CacheVolumeNames(name string) []string {
 	refName := []byte(fmt.Sprintf("%s:latest", name))
-
 	sum := sha256.Sum256(refName)
+
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) == 2 {
+		name = parts[1]
+	}
 
 	var volumes []string
 	for _, t := range []string{"build", "launch", "cache"} {
 		volumes = append(volumes, fmt.Sprintf("pack-cache-%x.%s", sum[:6], t))
+		volumes = append(volumes, fmt.Sprintf("pack-cache-%s_latest-%x.%s", name, sum[:6], t))
 	}
 
 	return volumes

--- a/cache_volume_names_test.go
+++ b/cache_volume_names_test.go
@@ -15,8 +15,24 @@ func testCacheVolumeNames(t *testing.T, context spec.G, it spec.S) {
 	it("returns the name of the cache volumes that are assigned to an image", func() {
 		Expect(occam.CacheVolumeNames("some-app")).To(Equal([]string{
 			"pack-cache-16fe664c76f0.build",
+			"pack-cache-some-app_latest-16fe664c76f0.build",
 			"pack-cache-16fe664c76f0.launch",
+			"pack-cache-some-app_latest-16fe664c76f0.launch",
 			"pack-cache-16fe664c76f0.cache",
+			"pack-cache-some-app_latest-16fe664c76f0.cache",
 		}))
+	})
+
+	context("when the name includes a registry", func() {
+		it("returns the name of the cache volumes that are assigned to an image", func() {
+			Expect(occam.CacheVolumeNames("occam.example.com/some-app")).To(Equal([]string{
+				"pack-cache-e69d3a4f1e12.build",
+				"pack-cache-some-app_latest-e69d3a4f1e12.build",
+				"pack-cache-e69d3a4f1e12.launch",
+				"pack-cache-some-app_latest-e69d3a4f1e12.launch",
+				"pack-cache-e69d3a4f1e12.cache",
+				"pack-cache-some-app_latest-e69d3a4f1e12.cache",
+			}))
+		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The `pack` 0.17.0 release included what seemed to be an [innocuous change](https://github.com/buildpacks/pack/pull/1039) to the naming of the cache volumes. Unfortunately, this change resulted in our test harness failing to remove volumes after the tests were complete, and thus causing us to run out of disk when running certain test suites on constrained environments like GitHub Actions.

This change updates the list of volume names to remove such that includes the superset of those that would work for all versions of `pack`, including the latest 0.17.0 release.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
