### PR TITLE
add WithVolume support

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -113,6 +113,7 @@ type DockerContainerRun struct {
 	entrypoint   string
 	publishPorts []string
 	publishAll   bool
+	volume       string
 }
 
 func (r DockerContainerRun) WithEnv(env map[string]string) DockerContainerRun {
@@ -147,6 +148,11 @@ func (r DockerContainerRun) WithPublish(value string) DockerContainerRun {
 
 func (r DockerContainerRun) WithPublishAll() DockerContainerRun {
 	r.publishAll = true
+	return r
+}
+
+func (r DockerContainerRun) WithVolume(volume string) DockerContainerRun {
+	r.volume = volume
 	return r
 }
 
@@ -186,6 +192,10 @@ func (r DockerContainerRun) Execute(imageID string) (Container, error) {
 
 	if r.entrypoint != "" {
 		args = append(args, "--entrypoint", r.entrypoint)
+	}
+
+	if r.volume != "" {
+		args = append(args, "--volume", r.volume)
 	}
 
 	args = append(args, imageID)

--- a/docker_test.go
+++ b/docker_test.go
@@ -441,6 +441,27 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
+			context("when given optionial volume setting", func() {
+				it("sets the volume flag on the run command", func() {
+					container, err := docker.Container.Run.
+						WithVolume("/tmp/host-source:/tmp/dir-on-container:rw").
+						Execute("some-image-id")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(container).To(Equal(occam.Container{
+						ID: "some-container-id",
+					}))
+
+					Expect(executeArgs).To(HaveLen(2))
+					Expect(executeArgs[0]).To(Equal([]string{
+						"container", "run",
+						"--detect",
+						"--volume", "/tmp/host-source:/tmp/dir-on-container:rw",
+						"some-image-id",
+					}))
+				})
+			})
+
 			context("failure cases", func() {
 				context("when the executable fails", func() {
 					it.Before(func() {

--- a/docker_test.go
+++ b/docker_test.go
@@ -455,7 +455,7 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 					Expect(executeArgs).To(HaveLen(2))
 					Expect(executeArgs[0]).To(Equal([]string{
 						"container", "run",
-						"--detect",
+						"--detach",
 						"--volume", "/tmp/host-source:/tmp/dir-on-container:rw",
 						"some-image-id",
 					}))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds `WithVolume` to `DockerContainerRun` objects. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

This will allow us to set volume mounts when testing with occam docker containers in our tests. 
This came about as a part of https://github.com/paketo-buildpacks/nodejs/issues/308 since we will need to volume mount CA certificate bindings into the container.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
