### PR TITLE
Fixes action that increments tag in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,7 +34,7 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Tag
       id: tag
-      uses: paketo-buildpacks/github-config/actions/tag@main
+      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
     - name: Create Draft Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The location of the action that increments the tag for a release was moved as part of https://github.com/paketo-buildpacks/github-config/pull/258. This fixes the release workflow to point to this new location.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
