### PR TITLE
add WithPackager to buildpackstore

### DIFF
--- a/buildpack_store.go
+++ b/buildpack_store.go
@@ -13,11 +13,13 @@ import (
 
 //go:generate faux --interface LocalFetcher --output fakes/local_fetcher.go
 type LocalFetcher interface {
+	WithPackager(packager freezer.Packager) freezer.LocalFetcher
 	Get(freezer.LocalBuildpack) (string, error)
 }
 
 //go:generate faux --interface RemoteFetcher --output fakes/remote_fetcher.go
 type RemoteFetcher interface {
+	WithPackager(packager freezer.Packager) freezer.RemoteFetcher
 	Get(freezer.RemoteBuildpack) (string, error)
 }
 
@@ -71,6 +73,12 @@ func (bs BuildpackStore) WithRemoteFetcher(fetcher RemoteFetcher) BuildpackStore
 
 func (bs BuildpackStore) WithCacheManager(manager CacheManager) BuildpackStore {
 	bs.Get.cacheManager = manager
+	return bs
+}
+
+func (bs BuildpackStore) WithPackager(packager freezer.Packager) BuildpackStore {
+	bs.Get.local = bs.Get.local.WithPackager(packager)
+	bs.Get.remote = bs.Get.remote.WithPackager(packager)
 	return bs
 }
 

--- a/fakes/cache_manager.go
+++ b/fakes/cache_manager.go
@@ -8,7 +8,7 @@ import (
 
 type CacheManager struct {
 	CloseCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Returns   struct {
 			Error error
@@ -16,7 +16,7 @@ type CacheManager struct {
 		Stub func() error
 	}
 	DirCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Returns   struct {
 			String string
@@ -24,7 +24,7 @@ type CacheManager struct {
 		Stub func() string
 	}
 	GetCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Key string
@@ -37,7 +37,7 @@ type CacheManager struct {
 		Stub func(string) (freezer.CacheEntry, bool, error)
 	}
 	OpenCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Returns   struct {
 			Error error
@@ -45,7 +45,7 @@ type CacheManager struct {
 		Stub func() error
 	}
 	SetCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Key         string
@@ -59,8 +59,8 @@ type CacheManager struct {
 }
 
 func (f *CacheManager) Close() error {
-	f.CloseCall.Lock()
-	defer f.CloseCall.Unlock()
+	f.CloseCall.mutex.Lock()
+	defer f.CloseCall.mutex.Unlock()
 	f.CloseCall.CallCount++
 	if f.CloseCall.Stub != nil {
 		return f.CloseCall.Stub()
@@ -68,8 +68,8 @@ func (f *CacheManager) Close() error {
 	return f.CloseCall.Returns.Error
 }
 func (f *CacheManager) Dir() string {
-	f.DirCall.Lock()
-	defer f.DirCall.Unlock()
+	f.DirCall.mutex.Lock()
+	defer f.DirCall.mutex.Unlock()
 	f.DirCall.CallCount++
 	if f.DirCall.Stub != nil {
 		return f.DirCall.Stub()
@@ -77,8 +77,8 @@ func (f *CacheManager) Dir() string {
 	return f.DirCall.Returns.String
 }
 func (f *CacheManager) Get(param1 string) (freezer.CacheEntry, bool, error) {
-	f.GetCall.Lock()
-	defer f.GetCall.Unlock()
+	f.GetCall.mutex.Lock()
+	defer f.GetCall.mutex.Unlock()
 	f.GetCall.CallCount++
 	f.GetCall.Receives.Key = param1
 	if f.GetCall.Stub != nil {
@@ -87,8 +87,8 @@ func (f *CacheManager) Get(param1 string) (freezer.CacheEntry, bool, error) {
 	return f.GetCall.Returns.CacheEntry, f.GetCall.Returns.Bool, f.GetCall.Returns.Error
 }
 func (f *CacheManager) Open() error {
-	f.OpenCall.Lock()
-	defer f.OpenCall.Unlock()
+	f.OpenCall.mutex.Lock()
+	defer f.OpenCall.mutex.Unlock()
 	f.OpenCall.CallCount++
 	if f.OpenCall.Stub != nil {
 		return f.OpenCall.Stub()
@@ -96,8 +96,8 @@ func (f *CacheManager) Open() error {
 	return f.OpenCall.Returns.Error
 }
 func (f *CacheManager) Set(param1 string, param2 freezer.CacheEntry) error {
-	f.SetCall.Lock()
-	defer f.SetCall.Unlock()
+	f.SetCall.mutex.Lock()
+	defer f.SetCall.mutex.Unlock()
 	f.SetCall.CallCount++
 	f.SetCall.Receives.Key = param1
 	f.SetCall.Receives.CachedEntry = param2

--- a/fakes/docker_image_inspect_client.go
+++ b/fakes/docker_image_inspect_client.go
@@ -8,7 +8,7 @@ import (
 
 type DockerImageInspectClient struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Ref string
@@ -22,8 +22,8 @@ type DockerImageInspectClient struct {
 }
 
 func (f *DockerImageInspectClient) Execute(param1 string) (occam.Image, error) {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Ref = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/local_fetcher.go
+++ b/fakes/local_fetcher.go
@@ -8,7 +8,7 @@ import (
 
 type LocalFetcher struct {
 	GetCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			LocalBuildpack freezer.LocalBuildpack
@@ -19,15 +19,36 @@ type LocalFetcher struct {
 		}
 		Stub func(freezer.LocalBuildpack) (string, error)
 	}
+	WithPackagerCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Packager freezer.Packager
+		}
+		Returns struct {
+			LocalFetcher freezer.LocalFetcher
+		}
+		Stub func(freezer.Packager) freezer.LocalFetcher
+	}
 }
 
 func (f *LocalFetcher) Get(param1 freezer.LocalBuildpack) (string, error) {
-	f.GetCall.Lock()
-	defer f.GetCall.Unlock()
+	f.GetCall.mutex.Lock()
+	defer f.GetCall.mutex.Unlock()
 	f.GetCall.CallCount++
 	f.GetCall.Receives.LocalBuildpack = param1
 	if f.GetCall.Stub != nil {
 		return f.GetCall.Stub(param1)
 	}
 	return f.GetCall.Returns.String, f.GetCall.Returns.Error
+}
+func (f *LocalFetcher) WithPackager(param1 freezer.Packager) freezer.LocalFetcher {
+	f.WithPackagerCall.mutex.Lock()
+	defer f.WithPackagerCall.mutex.Unlock()
+	f.WithPackagerCall.CallCount++
+	f.WithPackagerCall.Receives.Packager = param1
+	if f.WithPackagerCall.Stub != nil {
+		return f.WithPackagerCall.Stub(param1)
+	}
+	return f.WithPackagerCall.Returns.LocalFetcher
 }

--- a/fakes/remote_fetcher.go
+++ b/fakes/remote_fetcher.go
@@ -8,7 +8,7 @@ import (
 
 type RemoteFetcher struct {
 	GetCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			RemoteBuildpack freezer.RemoteBuildpack
@@ -19,15 +19,36 @@ type RemoteFetcher struct {
 		}
 		Stub func(freezer.RemoteBuildpack) (string, error)
 	}
+	WithPackagerCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Packager freezer.Packager
+		}
+		Returns struct {
+			RemoteFetcher freezer.RemoteFetcher
+		}
+		Stub func(freezer.Packager) freezer.RemoteFetcher
+	}
 }
 
 func (f *RemoteFetcher) Get(param1 freezer.RemoteBuildpack) (string, error) {
-	f.GetCall.Lock()
-	defer f.GetCall.Unlock()
+	f.GetCall.mutex.Lock()
+	defer f.GetCall.mutex.Unlock()
 	f.GetCall.CallCount++
 	f.GetCall.Receives.RemoteBuildpack = param1
 	if f.GetCall.Stub != nil {
 		return f.GetCall.Stub(param1)
 	}
 	return f.GetCall.Returns.String, f.GetCall.Returns.Error
+}
+func (f *RemoteFetcher) WithPackager(param1 freezer.Packager) freezer.RemoteFetcher {
+	f.WithPackagerCall.mutex.Lock()
+	defer f.WithPackagerCall.mutex.Unlock()
+	f.WithPackagerCall.CallCount++
+	f.WithPackagerCall.Receives.Packager = param1
+	if f.WithPackagerCall.Stub != nil {
+		return f.WithPackagerCall.Stub(param1)
+	}
+	return f.WithPackagerCall.Returns.RemoteFetcher
 }

--- a/matchers/fakes/executable.go
+++ b/matchers/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This will allow users to create a BuildpackStore that knows how to fetch and package non-packit buildpacks. Users define their own packager that implements the `freezer.Packager` interface, and BuildpackStore handles the rest. Presto!

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
