### PR TITLE
add jam and libpak implementations of freezer.Packager

### DIFF
--- a/buildpack_store.go
+++ b/buildpack_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ForestEckhardt/freezer"
 	"github.com/ForestEckhardt/freezer/github"
+	"github.com/paketo-buildpacks/occam/packagers"
 )
 
 //go:generate faux --interface LocalFetcher --output fakes/local_fetcher.go
@@ -40,7 +41,7 @@ func NewBuildpackStore() BuildpackStore {
 	gitToken := os.Getenv("GIT_TOKEN")
 	cacheManager := freezer.NewCacheManager(filepath.Join(os.Getenv("HOME"), ".freezer-cache"))
 	releaseService := github.NewReleaseService(github.NewConfig("https://api.github.com", gitToken))
-	packager := freezer.NewPackingTools()
+	packager := packagers.NewJam()
 	fileSystem := freezer.NewFileSystem(ioutil.TempDir)
 	namer := freezer.NewNameGenerator()
 

--- a/packagers/fakes/executable.go
+++ b/packagers/fakes/executable.go
@@ -1,0 +1,32 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+type Executable struct {
+	ExecuteCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Execution pexec.Execution
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(pexec.Execution) error
+	}
+}
+
+func (f *Executable) Execute(param1 pexec.Execution) error {
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.Execution = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.Error
+}

--- a/packagers/init_test.go
+++ b/packagers/init_test.go
@@ -1,0 +1,15 @@
+package packagers_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitPackagers(t *testing.T) {
+	suite := spec.New("packagers", spec.Report(report.Terminal{}))
+	suite("Libpak", testLibpak)
+	suite("Jam", testJam)
+	suite.Run(t)
+}

--- a/packagers/jam.go
+++ b/packagers/jam.go
@@ -1,0 +1,47 @@
+package packagers
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+//go:generate faux --interface Executable --output fakes/executable.go
+type Executable interface {
+	Execute(pexec.Execution) error
+}
+
+type Jam struct {
+	executable Executable
+}
+
+func NewJam() Jam {
+	return Jam{
+		executable: pexec.NewExecutable("jam"),
+	}
+}
+
+func (j Jam) WithExecutable(executable Executable) Jam {
+	j.executable = executable
+	return j
+}
+
+func (j Jam) Execute(buildpackDir, output, version string, offline bool) error {
+	args := []string{
+		"pack",
+		"--buildpack", filepath.Join(buildpackDir, "buildpack.toml"),
+		"--output", output,
+		"--version", version,
+	}
+
+	if offline {
+		args = append(args, "--offline")
+	}
+
+	return j.executable.Execute(pexec.Execution{
+		Args:   args,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+}

--- a/packagers/jam.go
+++ b/packagers/jam.go
@@ -12,6 +12,10 @@ type Executable interface {
 	Execute(pexec.Execution) error
 }
 
+// jam is a packager that builds packit buildpacks' source code into tarballs.
+// This type wraps the jam executable, and implements the freezer.Packager
+// interface, and can therefore be passed as an argument to
+// occam.BuildpackStore.WithPackager().
 type Jam struct {
 	executable Executable
 }

--- a/packagers/jam_test.go
+++ b/packagers/jam_test.go
@@ -1,0 +1,68 @@
+package packagers_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/occam/fakes"
+	"github.com/paketo-buildpacks/occam/packagers"
+	"github.com/sclevine/spec"
+)
+
+func testJam(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		executable *fakes.Executable
+		packager   packagers.Jam
+	)
+
+	it.Before(func() {
+		executable = &fakes.Executable{}
+		packager = packagers.NewJam().WithExecutable(executable)
+
+	})
+
+	context("Execute", func() {
+		it("creates a correct pexec.Execution", func() {
+			err := packager.Execute("some-buildpack-dir", "some-output", "some-version", false)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"pack",
+				"--buildpack", filepath.Join("some-buildpack-dir", "buildpack.toml"),
+				"--output", "some-output",
+				"--version", "some-version",
+			}))
+		})
+
+		context("when packaging with offline dependencies", func() {
+			it("creates a correct pexec.Execution", func() {
+				err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"pack",
+					"--buildpack", filepath.Join("some-buildpack-dir", "buildpack.toml"),
+					"--output", "some-output",
+					"--version", "some-version",
+					"--offline",
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the execution returns an error", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Returns.Error = errors.New("some error")
+				})
+				it("returns an error", func() {
+					err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+					Expect(err).To(MatchError("some error"))
+				})
+			})
+		})
+	})
+}

--- a/packagers/libpak.go
+++ b/packagers/libpak.go
@@ -6,6 +6,10 @@ import (
 	"github.com/paketo-buildpacks/packit/pexec"
 )
 
+// create-package is a packager that builds libpak buildpacks' source code
+// into tarballs. This type wraps that packaging tool. Libpak implements the
+// freezer.Packager interface, and can therefore be passed as an argument to
+// occam.BuildpackStore.WithPackager().
 type Libpak struct {
 	executable Executable
 }

--- a/packagers/libpak.go
+++ b/packagers/libpak.go
@@ -1,0 +1,40 @@
+package packagers
+
+import (
+	"os"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+type Libpak struct {
+	executable Executable
+}
+
+func NewLibpak() Libpak {
+	return Libpak{
+		executable: pexec.NewExecutable("create-package"),
+	}
+}
+
+func (l Libpak) Execute(buildpackDir, output, version string, cached bool) error {
+	args := []string{
+		"--destination", output,
+		"--version", version,
+	}
+
+	if cached {
+		args = append(args, "--include-dependencies")
+	}
+
+	return l.executable.Execute(pexec.Execution{
+		Args:   args,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    buildpackDir,
+	})
+}
+
+func (l Libpak) WithExecutable(executable Executable) Libpak {
+	l.executable = executable
+	return l
+}

--- a/packagers/libpak_test.go
+++ b/packagers/libpak_test.go
@@ -1,0 +1,63 @@
+package packagers_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/occam/fakes"
+	"github.com/paketo-buildpacks/occam/packagers"
+	"github.com/sclevine/spec"
+)
+
+func testLibpak(t *testing.T, context spec.G, it spec.S) {
+
+	var (
+		Expect     = NewWithT(t).Expect
+		executable *fakes.Executable
+		packager   packagers.Libpak
+	)
+
+	it.Before(func() {
+		executable = &fakes.Executable{}
+		packager = packagers.NewLibpak().WithExecutable(executable)
+	})
+
+	context("Execute", func() {
+		it("calls the executable with the correct arguments", func() {
+			err := packager.Execute("some-buildpack-dir", "some-output-dir", "some-version", false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"--destination", "some-output-dir",
+				"--version", "some-version",
+			}))
+			Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal("some-buildpack-dir"))
+		})
+
+		context("when packaging with offline dependencies", func() {
+			it("adds the appropriate flag to the packager args", func() {
+				err := packager.Execute("some-buildpack-dir", "some-output-dir", "some-version", true)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"--destination", "some-output-dir",
+					"--version", "some-version",
+					"--include-dependencies",
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the execution returns an error", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Returns.Error = errors.New("some error")
+				})
+				it("returns an error", func() {
+					err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+					Expect(err).To(MatchError("some error"))
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds implementations of the `freezer.Packager` interface for `jam pack` and libpak's `create-package`. These can be used as arguments to `occam.BuildpackStore.WithPackager()`. Will enable users to easily select which packager is correct for the buildpacks they use in integration testing.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
