### PR TITLE
Support testing when Docker is not running locally

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,6 +2,8 @@ package occam
 
 import (
 	"encoding/json"
+	"net/url"
+	"os"
 	"strings"
 )
 
@@ -53,4 +55,18 @@ func NewContainerFromInspectOutput(output []byte) (Container, error) {
 
 func (c Container) HostPort(value string) string {
 	return c.Ports[value]
+}
+
+func (c Container) Host() string {
+	val, ok := os.LookupEnv("DOCKER_HOST")
+	if !ok || strings.HasPrefix(val, "unix://") {
+		return "localhost"
+	}
+
+	url, err := url.Parse(val)
+	if err != nil {
+		return "localhost"
+	}
+
+	return url.Hostname()
 }

--- a/matchers/be_available.go
+++ b/matchers/be_available.go
@@ -28,7 +28,7 @@ func (*BeAvailableMatcher) Match(actual interface{}) (bool, error) {
 
 	// Get a container port in order to look up the corresponding host port.
 	for port := range container.Ports {
-		response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort(port)))
+		response, err := http.Get(fmt.Sprintf("http://%s:%s", container.Host(), container.HostPort(port)))
 		if response != nil {
 			response.Body.Close()
 		}

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -74,7 +74,7 @@ func (sm *ServeMatcher) Match(actual interface{}) (success bool, err error) {
 		return false, fmt.Errorf("ServeMatcher looking for response from container port %s which is not in container port map", port)
 	}
 
-	response, err := http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort(port), sm.endpoint))
+	response, err := http.Get(fmt.Sprintf("http://%s:%s%s", container.Host(), container.HostPort(port), sm.endpoint))
 
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

This PR makes adjustments so that you can configure a remote host. It will look at and parse `DOCKER_HOST`. If not set, then it defaults to `localhost` which preserves the current behavior. If set, it will parse the URL and return the hostname so long as it's not a `unix://` socket.

## Use Cases

With the recent changes to Docker licensing, a user may not be running Docker on localhost. The occam code assumes that a test application will be accessible on `localhost` though. If you have a set up where Docker is running in a custom VM or even remotely. The occam matchers will always fail because nothing is available on localhost.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
