### PR TITLE
Add pack build --sbom-output-dir

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -58,15 +58,16 @@ type PackBuild struct {
 	verbose bool
 	noColor bool
 
-	buildpacks   []string
-	network      string
-	builder      string
-	clearCache   bool
-	env          map[string]string
-	trustBuilder bool
-	pullPolicy   string
-	volumes      []string
-	gid          string
+	buildpacks    []string
+	network       string
+	builder       string
+	clearCache    bool
+	env           map[string]string
+	trustBuilder  bool
+	pullPolicy    string
+	sbomOutputDir string
+	volumes       []string
+	gid           string
 
 	// TODO: remove after deprecation period
 	noPull bool
@@ -97,6 +98,11 @@ func (pb PackBuild) WithEnv(env map[string]string) PackBuild {
 	return pb
 }
 
+func (pb PackBuild) WithGID(gid string) PackBuild {
+	pb.gid = gid
+	return pb
+}
+
 // Deprecated: Use WithPullPolicy("never") instead.
 func (pb PackBuild) WithNoPull() PackBuild {
 	pb.noPull = true
@@ -108,6 +114,11 @@ func (pb PackBuild) WithPullPolicy(pullPolicy string) PackBuild {
 	return pb
 }
 
+func (pb PackBuild) WithSBOMOutputDir(output string) PackBuild {
+	pb.sbomOutputDir = output
+	return pb
+}
+
 func (pb PackBuild) WithTrustBuilder() PackBuild {
 	pb.trustBuilder = true
 	return pb
@@ -115,11 +126,6 @@ func (pb PackBuild) WithTrustBuilder() PackBuild {
 
 func (pb PackBuild) WithVolumes(volumes ...string) PackBuild {
 	pb.volumes = append(pb.volumes, volumes...)
-	return pb
-}
-
-func (pb PackBuild) WithGID(gid string) PackBuild {
-	pb.gid = gid
 	return pb
 }
 
@@ -171,6 +177,10 @@ func (pb PackBuild) Execute(name, path string) (Image, fmt.Stringer, error) {
 
 	if pb.pullPolicy != "" {
 		args = append(args, "--pull-policy", pb.pullPolicy)
+	}
+
+	if pb.sbomOutputDir != "" {
+		args = append(args, "--sbom-output-dir", pb.sbomOutputDir)
 	}
 
 	if pb.trustBuilder {

--- a/pack_test.go
+++ b/pack_test.go
@@ -239,6 +239,25 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when given optional sbom-output-dir", func() {
+			it("returns an image with the given name and the build logs", func() {
+				image, logs, err := pack.Build.WithSBOMOutputDir("some-dir").Execute("myapp", "/some/app/path")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(occam.Image{
+					ID: "some-image-id",
+				}))
+				Expect(logs.String()).To(Equal("some stdout output\nsome stderr output\n"))
+
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"build", "myapp",
+					"--path", "/some/app/path",
+					"--sbom-output-dir", "some-dir",
+				}))
+				Expect(dockerImageInspectClient.ExecuteCall.Receives.Ref).To(Equal("myapp"))
+			})
+		})
+
 		context("when given optional trust-builder", func() {
 			it("returns an image with the given name and the build logs", func() {
 				image, logs, err := pack.Build.WithTrustBuilder().Execute("myapp", "/some/app/path")


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #126 

## Use Cases
<!-- An explanation of the use cases your change enables -->
Easily extract SBOMs produced from builds. This unblocks paketo-buildpacks/go-mod-vendor#296 and many others.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
