### PR TITLE
Adds docker pull command

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -26,6 +26,8 @@ type Docker struct {
 	Volume struct {
 		Remove DockerVolumeRemove
 	}
+
+	Pull DockerPull
 }
 
 func NewDocker() Docker {
@@ -47,6 +49,8 @@ func NewDocker() Docker {
 
 	docker.Volume.Remove = DockerVolumeRemove{executable: executable}
 
+	docker.Pull = DockerPull{executable: executable}
+
 	return docker
 }
 
@@ -62,6 +66,8 @@ func (d Docker) WithExecutable(executable Executable) Docker {
 	d.Container.Stop.executable = executable
 
 	d.Volume.Remove.executable = executable
+
+	d.Pull.executable = executable
 
 	return d
 }
@@ -316,6 +322,24 @@ func (r DockerVolumeRemove) Execute(volumes []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to remove docker volume: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+type DockerPull struct {
+	executable Executable
+}
+
+func (p DockerPull) Execute(image string) error {
+
+	stderr := bytes.NewBuffer(nil)
+	err := p.executable.Execute(pexec.Execution{
+		Args:   []string{"pull", image},
+		Stderr: stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to pull docker image: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
 	return nil

--- a/docker_test.go
+++ b/docker_test.go
@@ -723,4 +723,32 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("Pull", func() {
+		it("will pull the given image", func() {
+			err := docker.Pull.Execute("some-image")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"pull", "some-image",
+			}))
+		})
+
+		context("failure cases", func() {
+			context("when the pull command fails", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintln(execution.Stderr, "Error: failed to pull image")
+						return errors.New("exit status 1")
+					}
+				})
+
+				it("returns an error", func() {
+					err := docker.Pull.Execute("some-image")
+					Expect(err).To(MatchError("failed to pull docker image: exit status 1: Error: failed to pull image"))
+				})
+			})
+
+		})
+	})
 }


### PR DESCRIPTION
By adding this we will be able to pull some of our more complicated setup into our test suite. It will also facilitate a use case where you want to test with an already released buildpack. For example in our `samples` or in our `buildpackless-builder` test

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
