### PR TITLE
Enable auto-approve and auto-merge for bot PRs

### DIFF
--- a/.github/workflows/approve-bot-prs.yml
+++ b/.github/workflows/approve-bot-prs.yml
@@ -1,0 +1,70 @@
+name: Approve Bot PRs
+
+on:
+  workflow_run:
+    workflows: ["Test Pull Request"]
+    types:
+    - completed
+
+jobs:
+  download:
+    name: Download PR Artifact
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-author: ${{ steps.pr-data.outputs.author }}
+      pr-number: ${{ steps.pr-data.outputs.number }}
+    steps:
+    - name: 'Download artifact'
+      uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+      with:
+        name: "event-payload"
+        repo: ${{ github.repository }}
+        run_id: ${{ github.event.workflow_run.id }}
+        workspace: "/github/workspace"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - id: pr-data
+      run: |
+        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
+  approve:
+    name: Approve Bot PRs
+    needs: download
+    if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: actions/checkout@v3
+
+    - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Enable Auto-Merge
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      run: |
+        echo "${GITHUB_TOKEN}" | gh auth login --with-token
+        gh pr merge ${{ needs.download.outputs.pr-number }} --auto --squash
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.18.x
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run Unit Tests
@@ -25,9 +25,9 @@ jobs:
     needs: unit
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v2.1.3
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.16.x
+        go-version: 1.18.x
     - name: Checkout
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.3.0
         with:
-          version: v1.32.2
+          version: v1.45.2

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.18
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run Unit Tests

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -18,3 +18,13 @@ jobs:
       uses: actions/checkout@v2
     - name: Run Unit Tests
       run: go test -v -count=1 ./...
+
+  upload:
+    name: Upload Workflow Event Payload
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: event-payload
+        path: ${{ github.event_path }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
An experiment that could help solve https://github.com/paketo-buildpacks/github-config/issues/451

Here, the workflow auto-approves PRs opened by bots that have only verified non-human commits. It also sets them to auto-merge once all required checks have passed. 

🚨 Before merging this PR, we'll need to turn on Enable Auto Merging in this repo's settings. 🚨 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
