### PR TITLE
Remove references to deprecated ioutil package.

### DIFF
--- a/buildpack_store.go
+++ b/buildpack_store.go
@@ -2,7 +2,6 @@ package occam
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ func NewBuildpackStore() BuildpackStore {
 	cacheManager := freezer.NewCacheManager(filepath.Join(os.Getenv("HOME"), ".freezer-cache"))
 	releaseService := github.NewReleaseService(github.NewConfig("https://api.github.com", gitToken))
 	packager := packagers.NewJam()
-	fileSystem := freezer.NewFileSystem(ioutil.TempDir)
+	fileSystem := freezer.NewFileSystem(os.MkdirTemp)
 	namer := freezer.NewNameGenerator()
 
 	return BuildpackStore{

--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -82,7 +82,7 @@ func (sm *ServeMatcher) Match(actual interface{}) (success bool, err error) {
 
 	if response != nil {
 		defer response.Body.Close()
-		content, err := ioutil.ReadAll(response.Body)
+		content, err := io.ReadAll(response.Body)
 		if err != nil {
 			return false, err
 		}

--- a/source.go
+++ b/source.go
@@ -2,14 +2,14 @@ package occam
 
 import (
 	"crypto/rand"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2/fs"
 )
 
 func Source(path string) (string, error) {
-	destination, err := ioutil.TempDir("", "source")
+	destination, err := os.MkdirTemp("", "source")
 	if err != nil {
 		return "", err
 	}
@@ -25,7 +25,7 @@ func Source(path string) (string, error) {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
+	err = os.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
 	if err != nil {
 		return "", err
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -1,7 +1,6 @@
 package occam_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,10 +21,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		source, err = ioutil.TempDir("", "source")
+		source, err = os.MkdirTemp("", "source")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(source, "some-file"), []byte("some-content"), 0644)
+		err = os.WriteFile(filepath.Join(source, "some-file"), []byte("some-content"), 0644)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -40,11 +39,11 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(destination).To(BeADirectory())
 
-		content, err := ioutil.ReadFile(filepath.Join(destination, "some-file"))
+		content, err := os.ReadFile(filepath.Join(destination, "some-file"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("some-content"))
 
-		content, err = ioutil.ReadFile(filepath.Join(destination, ".occam-key"))
+		content, err = os.ReadFile(filepath.Join(destination, ".occam-key"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(content).To(HaveLen(32))
 	})


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

This PR removes all references to the deprecated `ioutil` package and replaces them with their official replacements. See https://pkg.go.dev/io/ioutil for details on these replacements.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
