### PR TITLE
Add method to get container IP address

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -22,4 +22,26 @@ func testContainer(t *testing.T, context spec.G, it spec.S) {
 			Expect(container.HostPort("1234")).To(Equal("11111"))
 		})
 	})
+
+	context("IPAddressForNetwork", func() {
+		it("returns the IP Address associated ", func() {
+			container := occam.Container{
+				IPAddresses: map[string]string{
+					"bridge": "10.172.0.2",
+				},
+			}
+			Expect(container.IPAddressForNetwork("bridge")).To(Equal("10.172.0.2"))
+		})
+
+		context("failure cases", func() {
+			context("when the provided network does not exist", func() {
+				it("returns an error", func() {
+					container := occam.Container{}
+
+					_, err := container.IPAddressForNetwork("some-non-existent-network")
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -586,6 +586,11 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 								]
 							},
 							"NetworkSettings": {
+							  "Networks": {
+                  "bridge": {
+									  "IPAddress": "10.172.0.2"
+									}
+								},
 								"Ports": {
 									"8080/tcp": [
 										{
@@ -612,6 +617,9 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 					},
 					Ports: map[string]string{
 						"8080": "12345",
+					},
+					IPAddresses: map[string]string{
+						"bridge": "10.172.0.2",
 					},
 				}))
 


### PR DESCRIPTION


<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Add a helper method to a running `Container` object to obtain the IP address of the container on a given network.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This makes it easy to get the IP address of a running container for a given network name. Without this, you essentially have to run `docker inspect` and manually traverse the returned json.

Given that the default network is so often called `bridge`, I could see an argument for adding a second helper method to obtain the IP address on this specific network - something like this:

```
func (c Container) IPAddressForBridgeNetwork() string)
```

Signed-off-by: Sophie Wigmore <swigmore@vmware.com>

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
