### PR TITLE
Support running direct processes via docker helper

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -114,6 +114,7 @@ type DockerContainerRun struct {
 
 	command      string
 	commandArgs  []string
+	direct       bool
 	entrypoint   string
 	env          map[string]string
 	memory       string
@@ -143,6 +144,12 @@ func (r DockerContainerRun) WithCommandArgs(commandArgs []string) DockerContaine
 	r.commandArgs = commandArgs
 	return r
 }
+
+func (r DockerContainerRun) WithDirect() DockerContainerRun {
+	r.direct = true
+	return r
+}
+
 func (r DockerContainerRun) WithTTY() DockerContainerRun {
 	r.tty = true
 	return r
@@ -226,6 +233,10 @@ func (r DockerContainerRun) Execute(imageID string) (Container, error) {
 	}
 
 	args = append(args, imageID)
+
+	if r.direct {
+		args = append(args, "--")
+	}
 
 	if r.command != "" {
 		args = append(args, r.command)

--- a/docker.go
+++ b/docker.go
@@ -113,6 +113,7 @@ type DockerContainerRun struct {
 	inspect    DockerContainerInspect
 
 	command      string
+	commandArgs  []string
 	entrypoint   string
 	env          map[string]string
 	memory       string
@@ -138,6 +139,10 @@ func (r DockerContainerRun) WithCommand(command string) DockerContainerRun {
 	return r
 }
 
+func (r DockerContainerRun) WithCommandArgs(commandArgs []string) DockerContainerRun {
+	r.commandArgs = commandArgs
+	return r
+}
 func (r DockerContainerRun) WithTTY() DockerContainerRun {
 	r.tty = true
 	return r
@@ -225,6 +230,7 @@ func (r DockerContainerRun) Execute(imageID string) (Container, error) {
 	if r.command != "" {
 		args = append(args, r.command)
 	}
+	args = append(args, r.commandArgs...)
 
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)

--- a/docker_test.go
+++ b/docker_test.go
@@ -399,6 +399,30 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
+			context("when given optional command args", func() {
+				it("sets the command args on the run command", func() {
+					container, err := docker.Container.Run.
+						WithCommand("/some/command").
+						WithCommandArgs([]string{"arg1", "arg2"}).
+						Execute("some-image-id")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(container).To(Equal(occam.Container{
+						ID: "some-container-id",
+					}))
+
+					Expect(executeArgs).To(HaveLen(2))
+					Expect(executeArgs[0]).To(Equal([]string{
+						"container", "run",
+						"--detach",
+						"some-image-id",
+						"/some/command",
+						"arg1",
+						"arg2",
+					}))
+				})
+			})
+
 			context("when given optional tty setting", func() {
 				it("sets the tty flag on the run command", func() {
 					container, err := docker.Container.Run.

--- a/docker_test.go
+++ b/docker_test.go
@@ -423,6 +423,28 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
+			context("when given optional direct setting", func() {
+				it("runs the command directly (i.e. with '--' before command)", func() {
+					container, err := docker.Container.Run.
+						WithCommand("/some/command").
+						WithDirect().
+						Execute("some-image-id")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(container).To(Equal(occam.Container{
+						ID: "some-container-id",
+					}))
+
+					Expect(executeArgs).To(HaveLen(2))
+					Expect(executeArgs[0]).To(Equal([]string{
+						"container", "run",
+						"--detach",
+						"some-image-id",
+						"--",
+						"/some/command",
+					}))
+				})
+			})
 			context("when given optional tty setting", func() {
 				it("sets the tty flag on the run command", func() {
 					container, err := docker.Container.Run.


### PR DESCRIPTION
## Summary

As part of developing integration tests for the `jammy` tiny stack, we wanted to use the `occam` library to run an application image built with `pack build` with the new stack.

However, the `tiny` stack does not have a shell, meaning the docker command has to run directly, rather than with a shell. In practice this looks like:

```sh
docker run <image> -- <command> [args...]
```

Compared with the indirect invocation which looks like:

```sh
docker run <image> <command> [args...]
```

This requires two changes:

1. The ability to add the `--` flag to the docker command
2. The ability to specify the arguments that follow the command in docker run, rather than having the command include its arguments in a single string.

## Use Cases
<!-- An explanation of the use cases your change enables -->

The ability to use `occam`'s docker run helper with an image that doesn't have a shell (e.g. the `tiny` stack).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
