### PR TITLE
Adds --read-only and --mount flags to container run command

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -123,6 +123,8 @@ type DockerContainerRun struct {
 	publishPorts []string
 	tty          bool
 	volumes      []string
+	readOnly     bool
+	mounts       []string
 }
 
 func (r DockerContainerRun) WithEnv(env map[string]string) DockerContainerRun {
@@ -186,6 +188,16 @@ func (r DockerContainerRun) WithNetwork(network string) DockerContainerRun {
 	return r
 }
 
+func (r DockerContainerRun) WithReadOnly() DockerContainerRun {
+	r.readOnly = true
+	return r
+}
+
+func (r DockerContainerRun) WithMounts(mounts ...string) DockerContainerRun {
+	r.mounts = append(r.mounts, mounts...)
+	return r
+}
+
 func (r DockerContainerRun) Execute(imageID string) (Container, error) {
 	args := []string{"container", "run", "--detach"}
 
@@ -230,6 +242,14 @@ func (r DockerContainerRun) Execute(imageID string) (Container, error) {
 
 	for _, volume := range r.volumes {
 		args = append(args, "--volume", volume)
+	}
+
+	if r.readOnly {
+		args = append(args, "--read-only")
+	}
+
+	for _, mount := range r.mounts {
+		args = append(args, "--mount", mount)
 	}
 
 	args = append(args, imageID)

--- a/docker_test.go
+++ b/docker_test.go
@@ -325,6 +325,7 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 							return nil
 						}
 					})
+
 					it("sets all of the published ports in the run command", func() {
 						container, err := docker.Container.Run.
 							WithPublish("3000").
@@ -445,6 +446,7 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 					}))
 				})
 			})
+
 			context("when given optional tty setting", func() {
 				it("sets the tty flag on the run command", func() {
 					container, err := docker.Container.Run.
@@ -555,10 +557,10 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
-			context("when given optionial volume setting", func() {
-				it("sets the volume flag on the run command", func() {
+			context("when given optional read-only setting", func() {
+				it("sets the read-only flag on the run command", func() {
 					container, err := docker.Container.Run.
-						WithVolume("/tmp/host-source:/tmp/dir-on-container:rw").
+						WithReadOnly().
 						Execute("some-image-id")
 
 					Expect(err).NotTo(HaveOccurred())
@@ -570,7 +572,32 @@ func testDocker(t *testing.T, context spec.G, it spec.S) {
 					Expect(executeArgs[0]).To(Equal([]string{
 						"container", "run",
 						"--detach",
-						"--volume", "/tmp/host-source:/tmp/dir-on-container:rw",
+						"--read-only",
+						"some-image-id",
+					}))
+				})
+			})
+
+			context("when given optional mount setting", func() {
+				it("sets the mount flag on the run command", func() {
+					container, err := docker.Container.Run.
+						WithMounts(
+							"type=tmpfs,destination=/tmp",
+							"type=bind,source=/my-local,destination=/local",
+						).
+						Execute("some-image-id")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(container).To(Equal(occam.Container{
+						ID: "some-container-id",
+					}))
+
+					Expect(executeArgs).To(HaveLen(2))
+					Expect(executeArgs[0]).To(Equal([]string{
+						"container", "run",
+						"--detach",
+						"--mount", "type=tmpfs,destination=/tmp",
+						"--mount", "type=bind,source=/my-local,destination=/local",
 						"some-image-id",
 					}))
 				})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
By adding `WithReadOnly` and `WithMounts` we can test against containers that have their root filesystem marked as read-only.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Helps to resolve https://github.com/paketo-buildpacks/nginx/issues/385

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
