### PR TITLE
Adds pack builder inspect command

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,61 @@
+package occam
+
+type Builder struct {
+	BuilderName string      `json:"builder_name"`
+	Trusted     bool        `json:"trusted"`
+	Default     bool        `json:"default"`
+	LocalInfo   BuilderInfo `json:"local_info"`
+	RemoteInfo  BuilderInfo `json:"remote_info"`
+}
+
+type BuilderInfo struct {
+	Description    string                      `json:"description"`
+	CreatedBy      BuilderInfoCreatedBy        `json:"created_by"`
+	Stack          BuilderInfoStack            `json:"stack"`
+	Lifecycle      BuilderInfoLifecycle        `json:"lifecycle"`
+	RunImages      []BuilderInfoRunImage       `json:"run_images"`
+	Buildpacks     []BuilderInfoBuildpack      `json:"buildpacks"`
+	DetectionOrder []BuilderInfoDetectionOrder `json:"detection_order"`
+}
+
+type BuilderInfoCreatedBy struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type BuilderInfoStack struct {
+	ID string `json:"id"`
+}
+
+type BuilderInfoLifecycle struct {
+	Version       string                   `json:"version"`
+	BuildpackAPIs BuilderInfoLifecycleAPIs `json:"buildpack_apis"`
+	PlatformAPIs  BuilderInfoLifecycleAPIs `json:"platform_apis"`
+}
+
+type BuilderInfoLifecycleAPIs struct {
+	Deprecated []string `json:"deprecated"`
+	Supported  []string `json:"supported"`
+}
+
+type BuilderInfoRunImage struct {
+	Name string `json:"name"`
+}
+
+type BuilderInfoBuildpack struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Homepage string `json:"homepage"`
+}
+
+type BuilderInfoDetectionOrder struct {
+	Buildpacks []BuilderInfoDetectionOrderBuildpack `json:"buildpacks"`
+}
+
+type BuilderInfoDetectionOrderBuildpack struct {
+	ID         string                               `json:"id"`
+	Version    string                               `json:"version"`
+	Optional   bool                                 `json:"optional,omitempty"`
+	Buildpacks []BuilderInfoDetectionOrderBuildpack `json:"buildpacks"`
+}

--- a/init_test.go
+++ b/init_test.go
@@ -3,11 +3,14 @@ package occam_test
 import (
 	"testing"
 
+	"github.com/onsi/gomega/format"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 )
 
 func TestUnitOccam(t *testing.T) {
+	format.MaxLength = 0
+
 	suite := spec.New("occam", spec.Report(report.Terminal{}))
 	suite("CacheVolumeNames", testCacheVolumeNames)
 	suite("Container", testContainer)

--- a/pack_test.go
+++ b/pack_test.go
@@ -355,4 +355,372 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("Builder", func() {
+		context("Inspect", func() {
+			context("when given no builder image name", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintln(execution.Stdout, `{
+							"builder_name": "default-builder",
+							"trusted": true,
+							"default": true,
+							"local_info": {
+								"description": "some-builder-description",
+								"created_by": {
+									"name": "some-creator-name",
+									"version": "some-creator-version"
+								},
+								"stack": {
+									"id": "some-stack-id"
+								},
+								"lifecycle": {
+									"version": "some-lifecycle-version",
+									"buildpack_apis": {
+										"deprecated": [
+											"some-deprecated-api-version"
+										],
+										"supported": [
+											"some-api-version",
+											"other-api-version"
+										]
+									},
+									"platform_apis": {
+										"deprecated": [
+											"some-deprecated-api-version"
+										],
+										"supported": [
+											"some-api-version",
+											"other-api-version"
+										]
+									}
+								},
+								"run_images": [
+									{
+										"name": "some-run-image"
+									}
+								],
+								"buildpacks": [
+									{
+										"id": "some-buildpack-id",
+										"name": "some-buildpack-name",
+										"version": "some-buildpack-version",
+										"homepage": "some-buildpack-homepage"
+									},
+									{
+										"id": "other-buildpack-id",
+										"name": "other-buildpack-name",
+										"version": "other-buildpack-version",
+										"homepage": "other-buildpack-homepage"
+									}
+								],
+								"detection_order": [
+									{
+										"buildpacks": [
+											{
+												"id": "some-buildpack-id",
+												"version": "some-buildpack-version",
+												"buildpacks": [
+													{
+														"id": "other-buildpack-id",
+														"version": "other-buildpack-version",
+														"optional": true
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							"remote_info": {
+								"description": "some-builder-description",
+								"created_by": {
+									"name": "some-creator-name",
+									"version": "some-creator-version"
+								},
+								"stack": {
+									"id": "some-stack-id"
+								},
+								"lifecycle": {
+									"version": "some-lifecycle-version",
+									"buildpack_apis": {
+										"deprecated": [
+											"some-deprecated-api-version"
+										],
+										"supported": [
+											"some-api-version",
+											"other-api-version"
+										]
+									},
+									"platform_apis": {
+										"deprecated": [
+											"some-deprecated-api-version"
+										],
+										"supported": [
+											"some-api-version",
+											"other-api-version"
+										]
+									}
+								},
+								"run_images": [
+									{
+										"name": "some-run-image"
+									}
+								],
+								"buildpacks": [
+									{
+										"id": "some-buildpack-id",
+										"name": "some-buildpack-name",
+										"version": "some-buildpack-version",
+										"homepage": "some-buildpack-homepage"
+									},
+									{
+										"id": "other-buildpack-id",
+										"name": "other-buildpack-name",
+										"version": "other-buildpack-version",
+										"homepage": "other-buildpack-homepage"
+									}
+								],
+								"detection_order": [
+									{
+										"buildpacks": [
+											{
+												"id": "some-buildpack-id",
+												"version": "some-buildpack-version",
+												"buildpacks": [
+													{
+														"id": "other-buildpack-id",
+														"version": "other-buildpack-version",
+														"optional": true
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						}`)
+						return nil
+					}
+				})
+
+				it("returns the default builder", func() {
+					builder, err := pack.Builder.Inspect.Execute()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(builder).To(Equal(occam.Builder{
+						BuilderName: "default-builder",
+						Trusted:     true,
+						Default:     true,
+						LocalInfo: occam.BuilderInfo{
+							Description: "some-builder-description",
+							CreatedBy: occam.BuilderInfoCreatedBy{
+								Name:    "some-creator-name",
+								Version: "some-creator-version",
+							},
+							Stack: occam.BuilderInfoStack{
+								ID: "some-stack-id",
+							},
+							Lifecycle: occam.BuilderInfoLifecycle{
+								Version: "some-lifecycle-version",
+								BuildpackAPIs: occam.BuilderInfoLifecycleAPIs{
+									Deprecated: []string{
+										"some-deprecated-api-version",
+									},
+									Supported: []string{
+										"some-api-version",
+										"other-api-version",
+									},
+								},
+								PlatformAPIs: occam.BuilderInfoLifecycleAPIs{
+									Deprecated: []string{
+										"some-deprecated-api-version",
+									},
+									Supported: []string{
+										"some-api-version",
+										"other-api-version",
+									},
+								},
+							},
+							RunImages: []occam.BuilderInfoRunImage{
+								{Name: "some-run-image"},
+							},
+							Buildpacks: []occam.BuilderInfoBuildpack{
+								{
+									ID:       "some-buildpack-id",
+									Name:     "some-buildpack-name",
+									Version:  "some-buildpack-version",
+									Homepage: "some-buildpack-homepage",
+								},
+								{
+									ID:       "other-buildpack-id",
+									Name:     "other-buildpack-name",
+									Version:  "other-buildpack-version",
+									Homepage: "other-buildpack-homepage",
+								},
+							},
+							DetectionOrder: []occam.BuilderInfoDetectionOrder{
+								{
+									Buildpacks: []occam.BuilderInfoDetectionOrderBuildpack{
+										{
+											ID:      "some-buildpack-id",
+											Version: "some-buildpack-version",
+											Buildpacks: []occam.BuilderInfoDetectionOrderBuildpack{
+												{
+													ID:       "other-buildpack-id",
+													Version:  "other-buildpack-version",
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						RemoteInfo: occam.BuilderInfo{
+							Description: "some-builder-description",
+							CreatedBy: occam.BuilderInfoCreatedBy{
+								Name:    "some-creator-name",
+								Version: "some-creator-version",
+							},
+							Stack: occam.BuilderInfoStack{
+								ID: "some-stack-id",
+							},
+							Lifecycle: occam.BuilderInfoLifecycle{
+								Version: "some-lifecycle-version",
+								BuildpackAPIs: occam.BuilderInfoLifecycleAPIs{
+									Deprecated: []string{
+										"some-deprecated-api-version",
+									},
+									Supported: []string{
+										"some-api-version",
+										"other-api-version",
+									},
+								},
+								PlatformAPIs: occam.BuilderInfoLifecycleAPIs{
+									Deprecated: []string{
+										"some-deprecated-api-version",
+									},
+									Supported: []string{
+										"some-api-version",
+										"other-api-version",
+									},
+								},
+							},
+							RunImages: []occam.BuilderInfoRunImage{
+								{Name: "some-run-image"},
+							},
+							Buildpacks: []occam.BuilderInfoBuildpack{
+								{
+									ID:       "some-buildpack-id",
+									Name:     "some-buildpack-name",
+									Version:  "some-buildpack-version",
+									Homepage: "some-buildpack-homepage",
+								},
+								{
+									ID:       "other-buildpack-id",
+									Name:     "other-buildpack-name",
+									Version:  "other-buildpack-version",
+									Homepage: "other-buildpack-homepage",
+								},
+							},
+							DetectionOrder: []occam.BuilderInfoDetectionOrder{
+								{
+									Buildpacks: []occam.BuilderInfoDetectionOrderBuildpack{
+										{
+											ID:      "some-buildpack-id",
+											Version: "some-buildpack-version",
+											Buildpacks: []occam.BuilderInfoDetectionOrderBuildpack{
+												{
+													ID:       "other-buildpack-id",
+													Version:  "other-buildpack-version",
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}))
+
+					Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+						"builder", "inspect",
+						"--output", "json",
+					}))
+				})
+			})
+
+			context("when given a specific builder name", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintln(execution.Stdout, `{
+							"local_info": {
+								"stack": {
+									"id": "other-stack-id"
+								}
+							},
+							"remote_info": {
+								"stack": {
+									"id": "other-stack-id"
+								}
+							}
+						}`)
+						return nil
+					}
+				})
+
+				it("returns the builder matching that name", func() {
+					builder, err := pack.Builder.Inspect.Execute("other-builder")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(builder).To(Equal(occam.Builder{
+						LocalInfo: occam.BuilderInfo{
+							Stack: occam.BuilderInfoStack{
+								ID: "other-stack-id",
+							},
+						},
+						RemoteInfo: occam.BuilderInfo{
+							Stack: occam.BuilderInfoStack{
+								ID: "other-stack-id",
+							},
+						},
+					}))
+
+					Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+						"builder", "inspect", "other-builder",
+						"--output", "json",
+					}))
+				})
+			})
+
+			context("failure cases", func() {
+				context("when the pack executable fails", func() {
+					it.Before(func() {
+						executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+							fmt.Fprint(execution.Stdout, "some failure message")
+							return errors.New("some error")
+						}
+					})
+
+					it("returns an error", func() {
+						_, err := pack.Builder.Inspect.Execute()
+						Expect(err).To(MatchError("failed to pack builder inspect: some error\n\nOutput:\nsome failure message"))
+					})
+				})
+
+				context("when the pack returns unparseable JSON", func() {
+					it.Before(func() {
+						executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+							fmt.Fprintln(execution.Stdout, "%%%")
+							return nil
+						}
+					})
+
+					it("returns an error", func() {
+						_, err := pack.Builder.Inspect.Execute()
+						Expect(err).To(MatchError(ContainSubstring("failed to parse JSON: invalid character '%'")))
+					})
+				})
+			})
+		})
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This addition will provide a first-class API for inspecting the details of a builder.

## Use Cases
<!-- An explanation of the use cases your change enables -->
We have a few instances already across some test suites that could be improved if we used this common library code. For example, [this stack test helper function](https://github.com/paketo-buildpacks/jammy-tiny-stack/blob/6605249fa78f4a596be68dee8a9fa18054c9b46e/buildpack_integration_test.go#L176-L198).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
