### PR TITLE
Add BuildpackForKey helper method.

### DIFF
--- a/image.go
+++ b/image.go
@@ -77,3 +77,13 @@ func NewImageFromInspectOutput(output []byte) (Image, error) {
 		Labels:     inspect[0].Config.Labels,
 	}, nil
 }
+
+func (i Image) BuildpackForKey(key string) (ImageBuildpackMetadata, error) {
+	for _, buildpack := range i.Buildpacks {
+		if buildpack.Key == key {
+			return buildpack, nil
+		}
+	}
+
+	return ImageBuildpackMetadata{}, fmt.Errorf("no buildpack found for key: %s", key)
+}

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,68 @@
+package occam_test
+
+import (
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testImage(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("BuildpackForKey", func() {
+		it("returns the Buildpack with the key", func() {
+			image := occam.Image{
+				Buildpacks: []occam.ImageBuildpackMetadata{
+					{
+						Key: "first",
+						Layers: map[string]occam.ImageBuildpackMetadataLayer{
+							"first-layer-1": {
+								SHA: "first-layer-1-sha",
+							},
+							"first-layer-2": {
+								SHA: "first-layer-2-sha",
+							},
+						},
+					},
+					{
+						Key: "second",
+						Layers: map[string]occam.ImageBuildpackMetadataLayer{
+							"second-layer-1": {
+								SHA: "second-layer-1-sha",
+							},
+							"second-layer-2": {
+								SHA: "second-layer-2-sha",
+							},
+						},
+					},
+				},
+			}
+
+			firstBuildpack, err := image.BuildpackForKey("first")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(firstBuildpack.Key).To(Equal("first"))
+			Expect(firstBuildpack.Layers["first-layer-2"].SHA).To(Equal("first-layer-2-sha"))
+
+			secondBuildpack, err := image.BuildpackForKey("second")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secondBuildpack.Key).To(Equal("second"))
+			Expect(secondBuildpack.Layers["second-layer-2"].SHA).To(Equal("second-layer-2-sha"))
+		})
+
+		context("failure cases", func() {
+			context("when no buildpack exists with the provided key", func() {
+				it("returns an error", func() {
+					image := occam.Image{}
+
+					_, err := image.BuildpackForKey("some-non-existent-key")
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
+}

--- a/init_test.go
+++ b/init_test.go
@@ -15,6 +15,7 @@ func TestUnitOccam(t *testing.T) {
 	suite("CacheVolumeNames", testCacheVolumeNames)
 	suite("Container", testContainer)
 	suite("Docker", testDocker)
+	suite("Image", testImage)
 	suite("Pack", testPack)
 	suite("RandomName", testRandomName)
 	suite("Source", testSource)


### PR DESCRIPTION
## Summary

This PR adds a helper method on `occam.Image` to easily facilitate looking up the metadata for a buildpack by its key. This enables consumers to avoid iterating through the buildpack array and/or hard-coding buildpack index.

## Use Cases
<!-- An explanation of the use cases your change enables -->

There are multiple situations (e.g. [this](https://github.com/paketo-buildpacks/cpython/blob/4007b7fa690c607c3af8dde03d8a13b503256d05/integration/layer_reuse_test.go#L83-L84), and [this](https://github.com/paketo-buildpacks/go/blob/2b380ea3d70eec31da0ad48ef59495aa421409d0/integration/build_test.go#L129-L130)) where we hard-code the buildpack index. This is brittle, as it breaks if a buildpack is added to or removed from the build order.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
