### PR TITLE
Add matchers.BeAFileMatching

### DIFF
--- a/matchers/be_a_file_matching.go
+++ b/matchers/be_a_file_matching.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 )
 
 type BeAFileMatchingMatcher struct {
+	expected        interface{}
 	expectedMatcher types.GomegaMatcher
 	contents        string
 }
 
-func BeAFileMatching(expectedMatcher types.GomegaMatcher) *BeAFileMatchingMatcher {
+func BeAFileMatching(expected interface{}) *BeAFileMatchingMatcher {
 	return &BeAFileMatchingMatcher{
-		expectedMatcher: expectedMatcher,
+		expected: expected,
 	}
 }
 
@@ -24,6 +26,14 @@ func (matcher *BeAFileMatchingMatcher) Match(actual interface{}) (success bool, 
 	actualFilename, ok := actual.(string)
 	if !ok {
 		return false, fmt.Errorf("BeAFileMatchingMatcher expects a file path")
+	}
+
+	if expectedString, ok := matcher.expected.(string); ok {
+		matcher.expectedMatcher = gomega.Equal(expectedString)
+	} else {
+		if matcher.expectedMatcher, ok = matcher.expected.(types.GomegaMatcher); !ok {
+			return false, fmt.Errorf("BeAFileMatching expects a string or a types.GomegaMatcher")
+		}
 	}
 
 	bytes, err := os.ReadFile(actualFilename)

--- a/matchers/be_a_file_matching.go
+++ b/matchers/be_a_file_matching.go
@@ -1,0 +1,49 @@
+package matchers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/onsi/gomega/types"
+)
+
+type BeAFileMatchingMatcher struct {
+	expectedMatcher types.GomegaMatcher
+	contents        string
+}
+
+func BeAFileMatching(expectedMatcher types.GomegaMatcher) *BeAFileMatchingMatcher {
+	return &BeAFileMatchingMatcher{
+		expectedMatcher: expectedMatcher,
+	}
+}
+
+// Match will return whether the expectedMatcher matches on the file contents.
+// The file contents are saved for use in FailureMessage and NegatedFailureMessage.
+func (matcher *BeAFileMatchingMatcher) Match(actual interface{}) (success bool, err error) {
+	actualFilename, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("BeAFileMatchingMatcher expects a file path")
+	}
+
+	bytes, err := os.ReadFile(actualFilename)
+	if err != nil {
+		return false, err
+	}
+
+	matcher.contents = string(bytes)
+
+	return matcher.expectedMatcher.Match(matcher.contents)
+}
+
+// FailureMessage does not use the given param since it returns the expectedMatcher's failure message.
+// Requires Match to be called first to populate the file contents.
+func (matcher *BeAFileMatchingMatcher) FailureMessage(_ interface{}) string {
+	return matcher.expectedMatcher.FailureMessage(matcher.contents)
+}
+
+// NegatedFailureMessage does not use the given param since it returns the expectedMatcher's negated failure message.
+// Requires Match to be called first to populate the file contents.
+func (matcher *BeAFileMatchingMatcher) NegatedFailureMessage(_ interface{}) string {
+	return matcher.expectedMatcher.NegatedFailureMessage(matcher.contents)
+}

--- a/matchers/be_a_file_matching_test.go
+++ b/matchers/be_a_file_matching_test.go
@@ -1,0 +1,157 @@
+package matchers_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam/matchers"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBeAFileMatching(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect   = NewWithT(t).Expect
+		filename string
+		matcher  *matchers.BeAFileMatchingMatcher
+	)
+
+	it.Before(func() {
+		filename = filepath.Join(t.TempDir(), "file")
+
+		Expect(os.WriteFile(filename, []byte("hello world"), os.ModePerm)).To(Succeed())
+	})
+
+	context("will wrap ContainsSubstring", func() {
+		it("will pass", func() {
+			matcher = matchers.BeAFileMatching(ContainSubstring("hello"))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(true))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("will fail", func() {
+			matcher = matchers.BeAFileMatching(ContainSubstring("foobar"))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(false))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	context("will wrap Equal", func() {
+		it("will pass", func() {
+			matcher = matchers.BeAFileMatching(Equal("hello world"))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(true))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("will fail", func() {
+			matcher = matchers.BeAFileMatching(Equal("foobar"))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(false))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	context("will wrap MatchJSON", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filename, []byte(`[
+  {
+    "a": "b"
+  },
+  {
+    "c": [
+      1,
+      2,
+      3
+    ]
+  }
+]`), os.ModePerm)).To(Succeed())
+		})
+
+		it("will pass", func() {
+			matcher = matchers.BeAFileMatching(MatchJSON(`[{"a":"b"},{"c":[1,2,3]}]`))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(true))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("will fail", func() {
+			matcher = matchers.BeAFileMatching(MatchJSON(`{}`))
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(false))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	context("FailureMessage", func() {
+		it("wraps the given matcher", func() {
+			wrappedMatcher := Equal("hello")
+			matcher = matchers.BeAFileMatching(wrappedMatcher)
+
+			_, err := matcher.Match(filename)
+			Expect(err).NotTo(HaveOccurred())
+
+			message := matcher.FailureMessage(filename)
+			Expect(message).To(Equal(wrappedMatcher.FailureMessage("hello world")))
+		})
+	})
+
+	context("NegatedFailureMessage", func() {
+		it("wraps the given matcher", func() {
+			wrappedMatcher := BeNil()
+			matcher = matchers.BeAFileMatching(wrappedMatcher)
+
+			_, err := matcher.Match(filename)
+			Expect(err).NotTo(HaveOccurred())
+
+			message := matcher.NegatedFailureMessage(filename)
+			Expect(message).To(Equal(wrappedMatcher.NegatedFailureMessage("hello world")))
+		})
+	})
+
+	context("failure cases", func() {
+		context("Match is called with a non-string", func() {
+			it("will return an error", func() {
+				matcher = matchers.BeAFileMatching(ContainSubstring(""))
+				_, err := matcher.Match(42)
+				Expect(err).To(MatchError("BeAFileMatchingMatcher expects a file path"))
+			})
+		})
+
+		context("invalid filename", func() {
+			it.Before(func() {
+				filename = "foo/bar"
+			})
+
+			it("will return an error", func() {
+				matcher = matchers.BeAFileMatching(ContainSubstring(""))
+				_, err := matcher.Match(filename)
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			})
+		})
+
+		context("insufficient permissions", func() {
+			it.Before(func() {
+				tempDir := t.TempDir()
+				filename = filepath.Join(tempDir, "file")
+				Expect(os.Chmod(tempDir, 0000)).To(Succeed())
+			})
+
+			it("will return an error", func() {
+				matcher = matchers.BeAFileMatching(ContainSubstring(""))
+				_, err := matcher.Match(filename)
+				Expect(os.IsPermission(err)).To(BeTrue())
+			})
+		})
+	})
+}

--- a/matchers/be_a_file_matching_test.go
+++ b/matchers/be_a_file_matching_test.go
@@ -24,6 +24,24 @@ func testBeAFileMatching(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.WriteFile(filename, []byte("hello world"), os.ModePerm)).To(Succeed())
 	})
 
+	context("uses Equal by default", func() {
+		it("will pass", func() {
+			matcher = matchers.BeAFileMatching("hello world")
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(true))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("will fail", func() {
+			matcher = matchers.BeAFileMatching("foobar")
+
+			match, err := matcher.Match(filename)
+			Expect(match).To(Equal(false))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	context("will wrap ContainsSubstring", func() {
 		it("will pass", func() {
 			matcher = matchers.BeAFileMatching(ContainSubstring("hello"))
@@ -120,6 +138,14 @@ func testBeAFileMatching(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("failure cases", func() {
+		context("BeAFileMatching is called with a non-string and non-types.GomegaMatcher", func() {
+			it("will return an error", func() {
+				matcher = matchers.BeAFileMatching(42)
+				_, err := matcher.Match(filename)
+				Expect(err).To(MatchError("BeAFileMatching expects a string or a types.GomegaMatcher"))
+			})
+		})
+
 		context("Match is called with a non-string", func() {
 			it("will return an error", func() {
 				matcher = matchers.BeAFileMatching(ContainSubstring(""))

--- a/matchers/init_test.go
+++ b/matchers/init_test.go
@@ -12,5 +12,6 @@ func TestUnitMatchers(t *testing.T) {
 	suite("BeAvailable", testBeAvailable)
 	suite("ContainLines", testContainLines)
 	suite("Serve", testServe)
+	suite("BeAFileMatching", testBeAFileMatching)
 	suite.Run(t)
 }


### PR DESCRIPTION
Add matchers.BeAFileMatching, which will allow you to match the contents of a file without having to write the file-reading code yourself!