### PR TITLE
Add `SourceTesting`

### DIFF
--- a/fakes/simple_testing.go
+++ b/fakes/simple_testing.go
@@ -1,0 +1,46 @@
+package fakes
+
+import "sync"
+
+type SimpleTesting struct {
+	FatalfCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Format string
+			Args   []interface {
+			}
+		}
+		Stub func(string, ...interface {
+		})
+	}
+	TempDirCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Returns   struct {
+			String string
+		}
+		Stub func() string
+	}
+}
+
+func (f *SimpleTesting) Fatalf(param1 string, param2 ...interface {
+}) {
+	f.FatalfCall.mutex.Lock()
+	defer f.FatalfCall.mutex.Unlock()
+	f.FatalfCall.CallCount++
+	f.FatalfCall.Receives.Format = param1
+	f.FatalfCall.Receives.Args = param2
+	if f.FatalfCall.Stub != nil {
+		f.FatalfCall.Stub(param1, param2...)
+	}
+}
+func (f *SimpleTesting) TempDir() string {
+	f.TempDirCall.mutex.Lock()
+	defer f.TempDirCall.mutex.Unlock()
+	f.TempDirCall.CallCount++
+	if f.TempDirCall.Stub != nil {
+		return f.TempDirCall.Stub()
+	}
+	return f.TempDirCall.Returns.String
+}

--- a/source.go
+++ b/source.go
@@ -8,9 +8,14 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/fs"
 )
 
+// Source will copy `path` into a temporary directory and return the path to the temporary directory.
+// It will also place a file with random contents into the temporary directory, to ensure that the
+// contents are globally unique, which is meant to bypass reuse of cached layers.
+//
+// The caller must clean up the returned directory.
 func Source(path string) (string, error) {
 	destination, err := os.MkdirTemp("", "source")
-	if err != nil {
+	if err != nil { // untested
 		return "", err
 	}
 
@@ -21,12 +26,12 @@ func Source(path string) (string, error) {
 
 	content := make([]byte, 32)
 	_, err = rand.Read(content)
-	if err != nil {
+	if err != nil { // untested
 		return "", err
 	}
 
 	err = os.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
-	if err != nil {
+	if err != nil { // untested
 		return "", err
 	}
 

--- a/source.go
+++ b/source.go
@@ -15,27 +15,11 @@ import (
 // The caller must clean up the returned directory.
 func Source(path string) (string, error) {
 	destination, err := os.MkdirTemp("", "source")
-	if err != nil { // untested
-		return "", err
-	}
-
-	err = fs.Copy(path, destination)
 	if err != nil {
 		return "", err
 	}
 
-	content := make([]byte, 32)
-	_, err = rand.Read(content)
-	if err != nil { // untested
-		return "", err
-	}
-
-	err = os.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
-	if err != nil { // untested
-		return "", err
-	}
-
-	return destination, nil
+	return destination, move(path, destination)
 }
 
 type SimpleTesting interface {
@@ -53,19 +37,25 @@ type SimpleTesting interface {
 func SourceTesting(path string, t SimpleTesting) string {
 	destination := t.TempDir()
 
-	if err := fs.Copy(path, destination); err != nil {
+	if err := move(path, destination); err != nil {
 		t.Fatalf(err.Error())
+	}
+
+	return destination
+}
+
+func move(source, dest string) error {
+	err := fs.Copy(source, dest)
+	if err != nil {
+		return err
 	}
 
 	content := make([]byte, 32)
-	_, err := rand.Read(content)
+	_, err = rand.Read(content)
 	if err != nil { // untested
-		t.Fatalf(err.Error())
+		return err
 	}
 
-	err = os.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
-	if err != nil { // untested
-		t.Fatalf(err.Error())
-	}
-	return destination
+	// untested
+	return os.WriteFile(filepath.Join(dest, ".occam-key"), content, 0644)
 }

--- a/source.go
+++ b/source.go
@@ -37,3 +37,35 @@ func Source(path string) (string, error) {
 
 	return destination, nil
 }
+
+type SimpleTesting interface {
+	Fatalf(format string, args ...interface{})
+	TempDir() string
+}
+
+// SourceTesting will copy `path` into a temporary directory and return the path to the temporary directory.
+// It will also place a file with random contents into the temporary directory, to ensure that the
+// contents are globally unique, which is meant to bypass reuse of cached layers.
+//
+// SimpleTesting is implemented by *testing.T, so this function can easily be consumed by unit tests.
+// It will fail the tests instead of returning an error.
+// The temporary directory will be automatically cleaned up, see "testing.T".TempDir
+func SourceTesting(path string, t SimpleTesting) string {
+	destination := t.TempDir()
+
+	if err := fs.Copy(path, destination); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	content := make([]byte, 32)
+	_, err := rand.Read(content)
+	if err != nil { // untested
+		t.Fatalf(err.Error())
+	}
+
+	err = os.WriteFile(filepath.Join(destination, ".occam-key"), content, 0644)
+	if err != nil { // untested
+		t.Fatalf(err.Error())
+	}
+	return destination
+}

--- a/source_test.go
+++ b/source_test.go
@@ -34,14 +34,29 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(destination)).To(Succeed())
 	})
 
-	it("copies the given directory to a temporary directory with a random file added for uniqueness", func() {
-		var err error
-		destination, err = occam.Source(source)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(destination).To(BeADirectory())
+	context("Source", func() {
+		it("copies the given directory to a temporary directory with a random file added for uniqueness", func() {
+			var err error
+			destination, err = occam.Source(source)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destination).To(BeADirectory())
 
-		Expect(filepath.Join(destination, "some-file")).To(matchers.BeAFileMatching("some-content"))
-		Expect(filepath.Join(destination, ".occam-key")).To(matchers.BeAFileMatching(HaveLen(32)))
+			Expect(filepath.Join(destination, "some-file")).To(matchers.BeAFileMatching("some-content"))
+			Expect(filepath.Join(destination, ".occam-key")).To(matchers.BeAFileMatching(HaveLen(32)))
+		})
+
+		context("failure cases", func() {
+			context("when the source cannot be copied", func() {
+				it.Before(func() {
+					Expect(os.Chmod(filepath.Join(source, "some-file"), 0000)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := occam.Source(source)
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+		})
 	})
 
 	context("failure cases", func() {


### PR DESCRIPTION
Use `SourceTesting` instead of `Source` so that:
- It will clean up the temp dir automatically
- You don't have to check for returned errors (it will auto fail the test if there's a problem)