### PR TITLE
Add WithProtocol to Serve matcher.

### DIFF
--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -21,6 +21,7 @@ func Serve(expected interface{}) *ServeMatcher {
 	return &ServeMatcher{
 		expected: expected,
 		client:   http.DefaultClient,
+		protocol: "http",
 		docker:   occam.NewDocker(),
 	}
 }
@@ -29,6 +30,7 @@ type ServeMatcher struct {
 	expected        interface{}
 	port            int
 	endpoint        string
+	protocol        string
 	docker          occam.Docker
 	response        string
 	client          *http.Client
@@ -69,6 +71,13 @@ func (sm *ServeMatcher) WithEndpoint(endpoint string) *ServeMatcher {
 	return sm
 }
 
+// WithProtocol sets the protocol of the request.
+// For example, WithProtocol("https") will make an https request
+func (sm *ServeMatcher) WithProtocol(protocol string) *ServeMatcher {
+	sm.protocol = protocol
+	return sm
+}
+
 // WithDocker sets the occam.Docker that the matcher will use to access
 // the 'actual' container's metadata.
 func (sm *ServeMatcher) WithDocker(docker occam.Docker) *ServeMatcher {
@@ -104,7 +113,7 @@ func (sm *ServeMatcher) Match(actual interface{}) (success bool, err error) {
 		return false, errors.New(message)
 	}
 
-	response, err := sm.client.Get(fmt.Sprintf("http://%s:%s%s", container.Host(), container.HostPort(port), sm.endpoint))
+	response, err := sm.client.Get(fmt.Sprintf("%s://%s:%s%s", sm.protocol, container.Host(), container.HostPort(port), sm.endpoint))
 
 	if err != nil {
 		return false, err

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -214,6 +214,22 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when given a protocol", func() {
+			it.Before(func() {
+				matcher = matcher.WithProtocol("https")
+			})
+
+			it("uses provided protocol", func() {
+				_, err := matcher.Match(occam.Container{
+					Ports: map[string]string{
+						"8080": port,
+					},
+					Env: map[string]string{"PORT": "8080"},
+				})
+				Expect(err).To(MatchError(ContainSubstring("server gave HTTP response to HTTPS client")))
+			})
+		})
+
 		context("failure cases", func() {
 			context("the port is not in the container port mapping", func() {
 				it.Before(func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary & Use Cases

This PR adds a new `WithProtocol` method. This is useful for buildpacks which make `https` requests - like when httpd/nginx buildpacks leverage CA certificates.

## Discussion

It is hard to test this feature. I opted to validated that the request was made with `https` even though the server can't process that request. I did this by checking the returned error.

Configuring the server to respond to `https` requests is a lot of additional boilerplate, and I couldn't find another protocol that worked (e.g. `tcp` and `file` just returned an `unsupported protocol` error). I thought the `https` error is a more useful error to assert against.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
