### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+        echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> "$GITHUB_OUTPUT"
+        echo "number=$(cat event.json | jq -r '.pull_request.number')" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -62,7 +62,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:


### PR DESCRIPTION
## Summary

Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See also: https://github.com/paketo-buildpacks/github-config/pull/604

## Use Cases

Keep the pipelines alive.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
