### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -62,7 +62,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:


### PR DESCRIPTION
## Summary

Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

This is needed, because `workflows/create-draft-release.yml` is listed in `.syncignore`
https://github.com/paketo-buildpacks/occam/blob/26019f3b25dbef03eaac4323b3040cf587277a7e/.github/.syncignore#L2

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See also: https://github.com/paketo-buildpacks/github-config/pull/604

## Use Cases

Keep the pipelines alive.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
