### PR TITLE
update the `actions/upload-artifact` from v2 to v3

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}


### PR DESCRIPTION
## Summary

See https://github.com/paketo-buildpacks/github-config/pull/715

Manual update needed because `test-pull-request.yml` is part of `.syncignore` https://github.com/paketo-buildpacks/occam/blob/650b1d8359147894114b55d32ba707acf4f702b0/.github/.syncignore#L1

## Use Cases

Keep the pipelines alive

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
