### PR TITLE
Add --run-image for pack build

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -79,9 +79,15 @@ type PackBuild struct {
 	sbomOutputDir string
 	volumes       []string
 	gid           string
+	runImage      string
 
 	// TODO: remove after deprecation period
 	noPull bool
+}
+
+func (pb PackBuild) WithRunImage(runImage string) PackBuild {
+	pb.runImage = runImage
+	return pb
 }
 
 func (pb PackBuild) WithBuildpacks(buildpacks ...string) PackBuild {
@@ -213,6 +219,10 @@ func (pb PackBuild) Execute(name, path string) (Image, fmt.Stringer, error) {
 
 	if pb.gid != "" {
 		args = append(args, "--gid", pb.gid)
+	}
+
+	if pb.runImage != "" {
+		args = append(args, "--run-image", pb.runImage)
 	}
 
 	buildLogBuffer := bytes.NewBuffer(nil)

--- a/pack_test.go
+++ b/pack_test.go
@@ -302,6 +302,27 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when given optional run image", func() {
+			it("includes the --run-image option", func() {
+				image, logs, err := pack.Build.
+					WithRunImage("custom").
+					Execute("myapp", "/some/app/path")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(occam.Image{
+					ID: "some-image-id",
+				}))
+				Expect(logs.String()).To(Equal("some stdout output\nsome stderr output\n"))
+
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"build", "myapp",
+					"--path", "/some/app/path",
+					"--run-image", "custom",
+				}))
+				Expect(dockerImageInspectClient.ExecuteCall.Receives.Ref).To(Equal("myapp"))
+			})
+		})
+
 		context("when given optional gid", func() {
 			it("includes the --gid option and given argument on all commands", func() {
 				image, logs, err := pack.Build.


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This adds the possibility to use a dedicated run image when building with `'pack'.

## Use Cases
<!-- An explanation of the use cases your change enables -->
You want to test a specific run image and not the one from the stack.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
