### PR TITLE
Allow additional build args for pack build

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -68,21 +68,27 @@ type PackBuild struct {
 	verbose bool
 	noColor bool
 
-	buildpacks    []string
-	extensions    []string
-	network       string
-	builder       string
-	clearCache    bool
-	env           map[string]string
-	trustBuilder  bool
-	pullPolicy    string
-	sbomOutputDir string
-	volumes       []string
-	gid           string
-	runImage      string
+	buildpacks          []string
+	extensions          []string
+	network             string
+	builder             string
+	clearCache          bool
+	env                 map[string]string
+	trustBuilder        bool
+	pullPolicy          string
+	sbomOutputDir       string
+	volumes             []string
+	gid                 string
+	runImage            string
+	additionalBuildArgs []string
 
 	// TODO: remove after deprecation period
 	noPull bool
+}
+
+func (pb PackBuild) WithAdditionalBuildArgs(args ...string) PackBuild {
+	pb.additionalBuildArgs = append(pb.additionalBuildArgs, args...)
+	return pb
 }
 
 func (pb PackBuild) WithRunImage(runImage string) PackBuild {
@@ -224,6 +230,8 @@ func (pb PackBuild) Execute(name, path string) (Image, fmt.Stringer, error) {
 	if pb.runImage != "" {
 		args = append(args, "--run-image", pb.runImage)
 	}
+
+	args = append(args, pb.additionalBuildArgs...)
 
 	buildLogBuffer := bytes.NewBuffer(nil)
 	err := pb.executable.Execute(pexec.Execution{

--- a/pack_test.go
+++ b/pack_test.go
@@ -346,6 +346,27 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when given additional build args", func() {
+			it("includes the additional args", func() {
+				image, logs, err := pack.Build.
+					WithAdditionalBuildArgs("--not-supported-yet", "true").
+					Execute("myapp", "/some/app/path")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(occam.Image{
+					ID: "some-image-id",
+				}))
+				Expect(logs.String()).To(Equal("some stdout output\nsome stderr output\n"))
+
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"build", "myapp",
+					"--path", "/some/app/path",
+					"--not-supported-yet", "true",
+				}))
+				Expect(dockerImageInspectClient.ExecuteCall.Receives.Ref).To(Equal("myapp"))
+			})
+		})
+
 		context("failure cases", func() {
 			context("when the executable fails", func() {
 				it.Before(func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This allows to add additional arguments to `pack build` that were not added yet in the fluent interface.

## Use Cases
<!-- An explanation of the use cases your change enables -->
When you realise in your test that a specific `pack build` argument is not yet supported by the fluent interface, this offers some mitigation. Otherwise, you would have to delay the test or use shell out and not `occam.Pack`.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
