### PR TITLE
Avoid accessing undefined hostports which causes an error

### DIFF
--- a/container.go
+++ b/container.go
@@ -42,7 +42,9 @@ func NewContainerFromInspectOutput(output []byte) (Container, error) {
 		container.Ports = make(map[string]string)
 
 		for key, value := range inspect[0].NetworkSettings.Ports {
-			container.Ports[strings.TrimSuffix(key, "/tcp")] = value[0].HostPort
+			if len(value) > 0 {
+				container.Ports[strings.TrimSuffix(key, "/tcp")] = value[0].HostPort
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR adds an extra check if the value is defined when accessing the port of the container inspect. 
https://github.com/paketo-buildpacks/occam/blob/0fb03539e1d75afb0b91051ba3a92a5197c78336/container.go#L44-L46
Specifically, there is a chance the container having a port which doesnt map on any host port. In that case there is no value and as a result when accessing the `value[0].HostPort` the function crashes.

With this PR we ensure that before accessing the value, the value is defined by checking the length of the array.

Unit tests for testing the `NewContainerFromInspectOutput` function has been added.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Safely accessing a potential undefined variable.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
