### PR TITLE
Add support for docker URI images in buildpackstore.

### DIFF
--- a/buildpack_store.go
+++ b/buildpack_store.go
@@ -107,6 +107,7 @@ func (g BuildpackStoreGet) Execute(url string) (string, error) {
 		if g.oci == nil {
 			return "", fmt.Errorf("must provide OCI fetcher to fetch OCI images")
 		}
+		url := strings.TrimPrefix(url, "docker://")
 		return url, g.oci.Execute(url)
 	}
 

--- a/buildpack_store_test.go
+++ b/buildpack_store_test.go
@@ -40,15 +40,15 @@ func testBuildpackStore(t *testing.T, when spec.G, it spec.S) {
 
 	when("getting an online buildpack", func() {
 		when("from a docker uri", func() {
-			it("returns the URI to the OCI image", func() {
+			it("returns the URI to the OCI image, stripping the docker:// protocol", func() {
 				local_url, err := buildpackStore.Get.
 					Execute("docker://some-image:tag")
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(local_url).To(Equal("docker://some-image:tag"))
+				Expect(local_url).To(Equal("some-image:tag"))
 
 				Expect(fakeDockerPull.ExecuteCall.CallCount).To(Equal(1))
-				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("docker://some-image:tag"))
+				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("some-image:tag"))
 
 				Expect(fakeCacheManager.OpenCall.CallCount).To(Equal(0))
 				Expect(fakeCacheManager.CloseCall.CallCount).To(Equal(0))
@@ -63,10 +63,10 @@ func testBuildpackStore(t *testing.T, when spec.G, it spec.S) {
 					Execute("docker://some-image:tag")
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(local_url).To(Equal("docker://some-image:tag"))
+				Expect(local_url).To(Equal("some-image:tag"))
 
 				Expect(fakeDockerPull.ExecuteCall.CallCount).To(Equal(1))
-				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("docker://some-image:tag"))
+				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("some-image:tag"))
 
 				Expect(fakeCacheManager.OpenCall.CallCount).To(Equal(0))
 				Expect(fakeCacheManager.CloseCall.CallCount).To(Equal(0))
@@ -81,10 +81,10 @@ func testBuildpackStore(t *testing.T, when spec.G, it spec.S) {
 					Execute("docker://some-image:tag")
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(local_url).To(Equal("docker://some-image:tag"))
+				Expect(local_url).To(Equal("some-image:tag"))
 
 				Expect(fakeDockerPull.ExecuteCall.CallCount).To(Equal(1))
-				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("docker://some-image:tag"))
+				Expect(fakeDockerPull.ExecuteCall.Receives.String).To(Equal("some-image:tag"))
 
 				Expect(fakeCacheManager.OpenCall.CallCount).To(Equal(0))
 				Expect(fakeCacheManager.CloseCall.CallCount).To(Equal(0))

--- a/fakes/docker_pull.go
+++ b/fakes/docker_pull.go
@@ -1,0 +1,28 @@
+package fakes
+
+import "sync"
+
+type BPStoreDockerPull struct {
+	ExecuteCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			String string
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(string) error
+	}
+}
+
+func (f *BPStoreDockerPull) Execute(param1 string) error {
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.String = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.Error
+}


### PR DESCRIPTION
## Summary / Use Cases

This PR adds support for docker/OCI images in the `buildpackstore`. This allows us to use pre-built images as dependent buildpacks instead of having to build them from scratch each time.

Using OCI images as dependencies has multiple advantages:

1. It is more correct, as we're testing against the actual buildpacks that have been created, rather than building from scratch.
2. Extending the above, point, it is trivially-easy to pin the dependent buildpacks to known versions. Currently that is quite difficult (potentially impossible) in occam/freezer.
3. It is more efficient and stable (as we can leverage the docker cache and not worry about accidentally corrupting the freezer cache)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
