### PR TITLE
Buildpack packaging should always target linux

### DIFF
--- a/packagers/jam.go
+++ b/packagers/jam.go
@@ -92,7 +92,7 @@ func (j Jam) Execute(buildpackDir, output, version string, offline bool) error {
 		output,
 		"--path", buildpackTarballPath,
 		"--format", "file",
-		"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 	}
 
 	return j.pack.Execute(pexec.Execution{

--- a/packagers/jam_test.go
+++ b/packagers/jam_test.go
@@ -55,7 +55,7 @@ func testJam(t *testing.T, context spec.G, it spec.S) {
 				"some-output",
 				"--path", filepath.Join("some-jam-output", "some-version.tgz"),
 				"--format", "file",
-				"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+				"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 			}))
 		})
 
@@ -77,7 +77,7 @@ func testJam(t *testing.T, context spec.G, it spec.S) {
 					"some-output",
 					"--path", filepath.Join("some-jam-output", "some-version.tgz"),
 					"--format", "file",
-					"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+					"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 				}))
 			})
 		})
@@ -115,7 +115,7 @@ func testJam(t *testing.T, context spec.G, it spec.S) {
 					"some-output",
 					"--path", filepath.Join("some-jam-output", "some-version.tgz"),
 					"--format", "file",
-					"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+					"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 				}))
 			})
 		})

--- a/packagers/libpak.go
+++ b/packagers/libpak.go
@@ -73,7 +73,7 @@ func (l Libpak) Execute(buildpackDir, output, version string, cached bool) error
 		output,
 		"--path", libpakOutput,
 		"--format", "file",
-		"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 	}
 
 	return l.pack.Execute(pexec.Execution{

--- a/packagers/libpak_test.go
+++ b/packagers/libpak_test.go
@@ -52,7 +52,7 @@ func testLibpak(t *testing.T, context spec.G, it spec.S) {
 				"some-output-dir",
 				"--path", "some-libpak-output-dir",
 				"--format", "file",
-				"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+				"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 			}))
 		})
 
@@ -72,7 +72,7 @@ func testLibpak(t *testing.T, context spec.G, it spec.S) {
 					"some-output-dir",
 					"--path", "some-libpak-output-dir",
 					"--format", "file",
-					"--target", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+					"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 				}))
 			})
 		})


### PR DESCRIPTION
This fixes issues when testing on macos

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
