### PR TITLE
Bump docker to version 26.1.5 to fix CVE-2024-41110

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/ForestEckhardt/freezer v0.1.0
-	github.com/docker/docker v26.1.4+incompatible
+	github.com/docker/docker v26.1.5+incompatible
 	github.com/google/go-containerregistry v0.20.2
 	github.com/oklog/ulid v1.3.1
 	github.com/onsi/gomega v1.34.1

--- a/go.sum
+++ b/go.sum
@@ -1329,6 +1329,8 @@ github.com/docker/docker v23.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bc
 github.com/docker/docker v23.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v26.1.4+incompatible h1:vuTpXDuoga+Z38m1OZHzl7NKisKWaWlhjQk7IDPSLsU=
 github.com/docker/docker v26.1.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change bumps the docker library to 26.1.5 to resolve [cve-2024-41110](https://avd.aquasec.com/nvd/2024/cve-2024-41110/).

## Use Cases
We noticed `HIGH` vulnerabilities when scanning containers built with the node-js buildpack caused by the `0-setup-symlinks` binary from the npm-install buildpack.

cccam is used here
https://github.com/paketo-buildpacks/npm-install/blob/a01f9fc34b8cb106f8c7503f13ab70952533f157/go.mod#L9

Sample output from trivy scan
```
layers/paketo-buildpacks_npm-install/launch-modules/exec.d/0-setup-symlinks (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌──────────────────────────┬────────────────┬──────────┬──────────────────────┬─────────────────────────────────┬────────────────────────────────────────────┐
│         Library          │ Vulnerability  │ Severity │  Installed Version   │          Fixed Version          │                   Title                    │
├──────────────────────────┼────────────────┼──────────┼──────────────────────┼─────────────────────────────────┼────────────────────────────────────────────┤
│ github.com/docker/docker │ CVE-2024-41110 │ CRITICAL │ v26.1.4+incompatible │ 23.0.15, 26.1.5, 27.1.1, 25.0.6 │ moby: Authz zero length regression         │
│                          │                │          │                      │                                 │ https://avd.aquasec.com/nvd/cve-2024-41110 │
└──────────────────────────┴────────────────┴──────────┴──────────────────────┴─────────────────────────────────┴────────────────────────────────────────────┘

```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
