### PR TITLE
fix: restore ability to use occam with extensions

### DIFF
--- a/packagers/jam.go
+++ b/packagers/jam.go
@@ -106,11 +106,21 @@ func (j Jam) Execute(buildpackDir, output, version string, offline bool) error {
 
 	}
 
-	args = []string{
-		"buildpack", "package",
-		output,
-		"--format", "file",
-		"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
+	if ( command == "--buildpack") {
+		args = []string{
+			"buildpack", "package",
+			output,
+			"--format", "file",
+			"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
+		}
+	} else {
+		// pack extension does not yet support multi-arch
+		// update to inclue --target once it does
+		args = []string{
+			"extension", "package",
+			output,
+			"--format", "file",
+		}
 	}
 
 	err = j.pack.Execute(pexec.Execution{

--- a/packagers/jam_test.go
+++ b/packagers/jam_test.go
@@ -109,10 +109,9 @@ func testJam(t *testing.T, context spec.G, it spec.S) {
 				}))
 
 				Expect(pack.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
-					"buildpack", "package",
+					"extension", "package",
 					"some-output",
 					"--format", "file",
-					"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
 				}))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Recent change to support multi-arch for buildpacks brokle occam for extensions. This was because extensions were being built with "pack buildpack package" which seems to work for extensions if a tgz is passed in but not an expanded directory.

Update to use "pack extension package" for extensions instead. Unfortunately pack does not yet seem to support multi-arch for extensions so we'll have to add the --target option for extensions after that has been added.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
