### PR TITLE
Fix linter issue

### DIFF
--- a/fakes/daemon_client.go
+++ b/fakes/daemon_client.go
@@ -46,10 +46,10 @@ type DockerDaemonClient struct {
 			Bool    bool
 		}
 		Returns struct {
-			ImageLoadResponse types.ImageLoadResponse
+			ImageLoadResponse image.LoadResponse
 			Error             error
 		}
-		Stub func(context.Context, io.Reader, bool) (types.ImageLoadResponse, error)
+		Stub func(context.Context, io.Reader, bool) (image.LoadResponse, error)
 	}
 	ImageSaveCall struct {
 		mutex     sync.Mutex
@@ -109,7 +109,7 @@ func (f *DockerDaemonClient) ImageInspectWithRaw(param1 context.Context, param2 
 	}
 	return f.ImageInspectWithRawCall.Returns.ImageInspect, f.ImageInspectWithRawCall.Returns.ByteSlice, f.ImageInspectWithRawCall.Returns.Error
 }
-func (f *DockerDaemonClient) ImageLoad(param1 context.Context, param2 io.Reader, param3 bool) (types.ImageLoadResponse, error) {
+func (f *DockerDaemonClient) ImageLoad(param1 context.Context, param2 io.Reader, param3 bool) (image.LoadResponse, error) {
 	f.ImageLoadCall.mutex.Lock()
 	defer f.ImageLoadCall.mutex.Unlock()
 	f.ImageLoadCall.CallCount++


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes the linter issues which currently prevent the CI from a successful run. We adjusted the deprecated type `types.ImageLoadResponse`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
It enables the pipeline to run successfully and remove deprecated types.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
