### PR TITLE
feat: filematchers follow symlinks

### DIFF
--- a/matchers/have_file_test.go
+++ b/matchers/have_file_test.go
@@ -41,6 +41,18 @@ func testHaveFile(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("when the file exists as a symlink", func() {
+		it.Before(func() {
+			matcher = matchers.HaveFile("/etc/os-release")
+		})
+
+		it("matches", func() {
+			match, err := matcher.Match(image)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(match).To(BeTrue())
+		})
+	})
+
 	context("when the file does not exist", func() {
 		it.Before(func() {
 			matcher = matchers.HaveFile("/no/such/file")

--- a/matchers/have_file_with_content_test.go
+++ b/matchers/have_file_with_content_test.go
@@ -53,6 +53,30 @@ func testHaveFileWithContent(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("when the file exists as a symlink", func() {
+		it.Before(func() {
+			matcher = matchers.HaveFileWithContent("/etc/os-release", ContainSubstring("VERSION"))
+		})
+
+		it("matches", func() {
+			match, err := matcher.Match(image)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(match).To(BeTrue())
+		})
+
+		context("when the content doesn't match", func() {
+			it.Before(func() {
+				matcher = matchers.HaveFileWithContent("/etc/group", ContainSubstring("no such content"))
+			})
+
+			it("does not match", func() {
+				match, err := matcher.Match(image)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(match).To(BeFalse())
+			})
+		})
+	})
+
 	context("when the file does not exist", func() {
 		it.Before(func() {
 			matcher = matchers.HaveFileWithContent("/no/such/directory", "no such content")


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change introduces a new feature that allows users to include checking symlinks to files in their file matcher tests.

## Use Cases
<!-- An explanation of the use cases your change enables -->
When a user checks a file in an OCI image, using `have_file()` or `have_file_with_content()` would return `false` if the provided path was a symlink, regardless of the actual existence of the target file. With this feature, the functions now correctly follow symlinks to verify the existence and content of the target file.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
