### PR TITLE
Set PACK_VOLUME_KEY when performing pack build

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/paketo-buildpacks/packit/v2/pexec"
@@ -231,6 +232,9 @@ func (pb PackBuild) Execute(name, path string) (Image, fmt.Stringer, error) {
 		args = append(args, "--run-image", pb.runImage)
 	}
 
+	packEnv := os.Environ()
+	packEnv = append(packEnv, fmt.Sprintf("PACK_VOLUME_KEY=%s-volume", name))
+
 	args = append(args, pb.additionalBuildArgs...)
 
 	buildLogBuffer := bytes.NewBuffer(nil)
@@ -238,6 +242,7 @@ func (pb PackBuild) Execute(name, path string) (Image, fmt.Stringer, error) {
 		Args:   args,
 		Stdout: buildLogBuffer,
 		Stderr: buildLogBuffer,
+		Env:    packEnv,
 	})
 	if err != nil {
 		return Image{}, buildLogBuffer, fmt.Errorf("failed to pack build: %w\n\nOutput:\n%s", err, buildLogBuffer)

--- a/pack_test.go
+++ b/pack_test.go
@@ -97,6 +97,13 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 			Expect(dockerImageInspectClient.ExecuteCall.Receives.Ref).To(Equal("myapp"))
 		})
 
+		it("sets PACK_VOLUME_KEY", func() {
+			_, _, err := pack.Build.Execute("myapp", "/some/app/path")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement("PACK_VOLUME_KEY=myapp-volume"))
+		})
+
 		context("when given optional buildpacks", func() {
 			it("returns an image with the given name and the build logs", func() {
 				image, logs, err := pack.Build.


### PR DESCRIPTION
This PR ensures that pack sets `PACK_VOLUME_KEY` to a pseudo-random value (i.e. using the app name) when performing a pack build.

This should resolve issues we see that look like the following:

```
 Warning: PACK_VOLUME_KEY is unset; set this environment variable to a secret value to avoid creating a new volume cache on every build
            Using build cache volume 'pack-cache-01jq64mascyrse1j5kq131s6ct_latest-6308a6013b93.build'
            ERROR: failed to build: executing lifecycle: failed to read config file at path /home/runner/.pack/volume-keys.toml: toml: line 8 (last key "volume-keys.occam.example.com/01jq64mawftz3z4a7qbt4bh4en:latest"): Key 'volume-keys."occam.example.com/01jq64mawftz3z4a7qbt4bh4en:latest"' has already been defined.
```