### PR TITLE
Adding support for packaging multi-arch extension based on the OS architecture

### DIFF
--- a/packagers/jam_test.go
+++ b/packagers/jam_test.go
@@ -112,6 +112,7 @@ func testJam(t *testing.T, context spec.G, it spec.S) {
 					"extension", "package",
 					"some-output",
 					"--format", "file",
+					"--target", "linux/amd64",
 				}))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds the capability in occam to package a multi-arch extension based on the architecture of the OS, similar to what we do on buildpack but for extension.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
