### PR TITLE
Adding libpak tools as a packager for packaging buildpacks

### DIFF
--- a/packagers/init_test.go
+++ b/packagers/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestUnitPackagers(t *testing.T) {
 	suite := spec.New("packagers", spec.Report(report.Terminal{}))
 	suite("Libpak", testLibpak)
+	suite("LibpakTools", testLibpakTools)
 	suite("Jam", testJam)
 	suite.Run(t)
 }

--- a/packagers/libpak_tools.go
+++ b/packagers/libpak_tools.go
@@ -1,0 +1,84 @@
+package packagers
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+)
+
+// libpak-tools is a a number of helpful tools for the management and release of buildpacks.
+// Rereference repo: https://github.com/paketo-buildpacks/libpak-tools
+type LibpakTools struct {
+	executable Executable
+	pack       Executable
+	tempOutput func(dir string, pattern string) (string, error)
+}
+
+func NewLibpakTools() LibpakTools {
+	return LibpakTools{
+		executable: pexec.NewExecutable("libpak-tools"),
+		pack:       pexec.NewExecutable("pack"),
+		tempOutput: os.MkdirTemp,
+	}
+}
+
+func (l LibpakTools) WithExecutable(executable Executable) LibpakTools {
+	l.executable = executable
+	return l
+}
+
+func (l LibpakTools) WithPack(pack Executable) LibpakTools {
+	l.pack = pack
+	return l
+}
+
+func (l LibpakTools) WithTempOutput(tempOutput func(string, string) (string, error)) LibpakTools {
+	l.tempOutput = tempOutput
+	return l
+}
+
+func (l LibpakTools) Execute(buildpackDir, output, version string, cached bool) error {
+	libpakToolsOutput, err := l.tempOutput("", "")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(libpakToolsOutput)
+
+	args := []string{
+		"package", "compile",
+		"--source", buildpackDir,
+		"--destination", libpakToolsOutput,
+		"--version", version,
+	}
+
+	if cached {
+		args = append(args, "--include-dependencies")
+	}
+
+	err = l.executable.Execute(pexec.Execution{
+		Args:   args,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    buildpackDir,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	args = []string{
+		"buildpack", "package",
+		output,
+		"--path", libpakToolsOutput,
+		"--format", "file",
+		"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
+	}
+
+	return l.pack.Execute(pexec.Execution{
+		Args:   args,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+}

--- a/packagers/libpak_tools_test.go
+++ b/packagers/libpak_tools_test.go
@@ -1,0 +1,120 @@
+package packagers_test
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/occam/fakes"
+	"github.com/paketo-buildpacks/occam/packagers"
+	"github.com/sclevine/spec"
+)
+
+func testLibpakTools(t *testing.T, context spec.G, it spec.S) {
+
+	var (
+		Expect = NewWithT(t).Expect
+
+		executable *fakes.Executable
+		pack       *fakes.Executable
+
+		tempOutput func(string, string) (string, error)
+
+		packager packagers.LibpakTools
+	)
+
+	it.Before(func() {
+		executable = &fakes.Executable{}
+		pack = &fakes.Executable{}
+
+		tempOutput = func(string, string) (string, error) {
+			return "some-libpak-output-dir", nil
+		}
+
+		packager = packagers.NewLibpakTools().WithExecutable(executable).WithPack(pack).WithTempOutput(tempOutput)
+	})
+
+	context("Execute", func() {
+		it("calls the executable with the correct arguments", func() {
+			err := packager.Execute("some-buildpack-dir", "some-output-dir", "some-version", false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"package", "compile",
+				"--source", "some-buildpack-dir",
+				"--destination", "some-libpak-output-dir",
+				"--version", "some-version",
+			}))
+			Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal("some-buildpack-dir"))
+
+			Expect(pack.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"buildpack", "package",
+				"some-output-dir",
+				"--path", "some-libpak-output-dir",
+				"--format", "file",
+				"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
+			}))
+		})
+
+		context("when packaging with offline dependencies", func() {
+			it("adds the appropriate flag to the packager args", func() {
+				err := packager.Execute("some-buildpack-dir", "some-output-dir", "some-version", true)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"package", "compile",
+					"--source", "some-buildpack-dir",
+					"--destination", "some-libpak-output-dir",
+					"--version", "some-version",
+					"--include-dependencies",
+				}))
+
+				Expect(pack.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+					"buildpack", "package",
+					"some-output-dir",
+					"--path", "some-libpak-output-dir",
+					"--format", "file",
+					"--target", fmt.Sprintf("linux/%s", runtime.GOARCH),
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the tempDir creation fails returns an error", func() {
+				it.Before(func() {
+					tempOutput = func(string, string) (string, error) {
+						return "", errors.New("some tempDir error")
+					}
+
+					packager = packager.WithTempOutput(tempOutput)
+				})
+				it("returns an error", func() {
+					err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+					Expect(err).To(MatchError("some tempDir error"))
+				})
+			})
+
+			context("when the libpak execution returns an error", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Returns.Error = errors.New("some libpak error")
+				})
+				it("returns an error", func() {
+					err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+					Expect(err).To(MatchError("some libpak error"))
+				})
+			})
+
+			context("when the pack execution returns an error", func() {
+				it.Before(func() {
+					pack.ExecuteCall.Returns.Error = errors.New("some pack error")
+				})
+				it("returns an error", func() {
+					err := packager.Execute("some-buildpack-dir", "some-output", "some-version", true)
+					Expect(err).To(MatchError("some pack error"))
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds the libpak tools as a packager https://github.com/paketo-buildpacks/libpak-tools which is exactly the same as libpak https://github.com/paketo-buildpacks/libpak 

Specifically, it adds a new option called 	`packagers.NewLibpakTools()` which is similar to what `packagers.NewLibpak()`  but with libpak `2.0.0` .


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
