### PR TITLE
Add new WithAdditionalEnv helper function to pack build.

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -130,6 +130,16 @@ func (pb PackBuild) WithEnv(env map[string]string) PackBuild {
 	return pb
 }
 
+func (pb PackBuild) WithAdditionalEnv(env map[string]string) PackBuild {
+	if pb.env == nil {
+		pb.env = make(map[string]string)
+	}
+	for key, value := range env {
+		pb.env[key] = value
+	}
+	return pb
+}
+
 func (pb PackBuild) WithGID(gid string) PackBuild {
 	pb.gid = gid
 	return pb


### PR DESCRIPTION
## Summary

Add `WithAdditionalEnv()` helper function to the pack build process.

## Use Cases

This is useful when we want to initialize a pack build process once per test (or test suite) with common env vars, but then still want to be able to append test-specific env vars to the pack build process for individual tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
